### PR TITLE
chore: add project planning and repository guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/copilot-task.md
+++ b/.github/ISSUE_TEMPLATE/copilot-task.md
@@ -1,0 +1,31 @@
+---
+name: Copilot task
+about: Implementation task suitable for GitHub Copilot coding agent
+title: ""
+labels: ["copilot", "implementation"]
+assignees: ""
+---
+
+## Goal
+
+<!-- Describe the task. -->
+
+## Scope
+
+<!-- What should be changed? -->
+
+## Out of scope
+
+<!-- What should not be changed? -->
+
+## Acceptance criteria
+
+- [ ] `npm install` works
+- [ ] `npm run build` works
+- [ ] `npm test` works
+- [ ] Documentation is updated if needed
+- [ ] No credentials or secrets are committed
+
+## Copilot instructions
+
+Follow `AGENTS.md` and `.github/copilot-instructions.md`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,27 +1,80 @@
-# GitHub Copilot Instructions
+# GitHub Copilot Instructions — Oda Agent Kit
 
-This is the `oda-agent-kit` TypeScript monorepo. Follow the guidelines in [AGENTS.md](../AGENTS.md) at all times.
+## Project identity
 
-## Key Points for Copilot
+This repository is a TypeScript npm workspace monorepo for Oda grocery automation.
 
-- Language: **TypeScript** with strict mode enabled.
-- Package manager: **npm workspaces** (never use yarn or pnpm).
-- Build: each package has its own `tsc` invocation; the root `npm run build` runs all.
-- Testing: use **Jest** with `ts-jest` in each package.
-- Node.js ≥ 18 required.
+The main design goal is reusable domain logic in `packages/core`, with separate adapters for CLI, MCP, and OpenClaw.
 
-## Scope of Each Package
+## Always follow these rules
 
-| Package | Responsibility |
-|---------|---------------|
-| `@oda-agent/core` | HTTP client for the Oda API, data types, session management |
-| `@oda-agent/cli` | `commander`-based CLI; delegates all API calls to `@oda-agent/core` |
-| `@oda-agent/mcp-server` | MCP server using `@modelcontextprotocol/sdk`; wraps `@oda-agent/core` tools |
-| `@oda-agent/openclaw-plugin` | OpenClaw plugin factory; uses `@oda-agent/core` for data |
+1. Keep Oda business logic in `packages/core`.
+2. Keep CLI, MCP, and OpenClaw packages thin.
+3. Use TypeScript strict mode.
+4. Respect the repository's current module/test setup when editing (`CommonJS` + `Jest`), unless the task explicitly includes migration work.
+5. Add Zod schemas at API boundaries when introducing or changing external response parsing.
+6. Prefer fixture-backed tests for domain transformations and parsing.
+7. Do not implement final order placement in the initial version.
+8. Do not store credentials in the repo.
+9. Do not log secrets, cookies, CSRF tokens, or session IDs.
+10. For MCP stdio server, write logs to stderr, not stdout.
 
-## Don'ts
+## Preferred coding style
 
-- Do **not** make HTTP calls outside of `@oda-agent/core`.
-- Do **not** commit `.env` files.
-- Do **not** add `console.log` debug statements to production code.
-- Do **not** use `any` types; use `unknown` and narrow when necessary.
+- Small files with single responsibility.
+- Explicit exported interfaces.
+- Runtime validation for external API responses.
+- No hidden network calls in constructors.
+- Return structured result objects instead of printing from library code.
+- Adapter packages may format output, but core must not.
+
+## Current stack notes
+
+- Current tests use Jest (`ts-jest`) per package.
+- Current tsconfig base is CommonJS.
+- Planned migrations (ESM, wider runtime validation) should be explicit and repo-wide, not partial.
+
+## Initial package dependency rules
+
+Allowed:
+
+```text
+@oda-agent/cli -> @oda-agent/core
+@oda-agent/mcp-server -> @oda-agent/core
+@oda-agent/openclaw-plugin -> @oda-agent/core
+```
+
+Not allowed:
+
+```text
+@oda-agent/core -> any adapter package
+@oda-agent/mcp-server -> @oda-agent/cli
+@oda-agent/openclaw-plugin -> @oda-agent/cli
+@oda-agent/openclaw-plugin -> @oda-agent/mcp-server
+```
+
+## Commands that should work
+
+```bash
+npm install
+npm run build
+npm test
+npm run lint
+```
+
+## Important domain behavior
+
+The assistant/user workflow should be:
+
+1. Read current cart, order history, saved lists, and delivery slots.
+2. Build a proposed grocery plan.
+3. Explain why each item is suggested.
+4. Ask for confirmation before cart mutation.
+5. Ask for stronger confirmation before delivery-slot changes.
+6. Never place an order automatically.
+
+## Initial milestone
+
+For the first milestone, create the project structure, TypeScript configuration, package manifests, placeholder interfaces, fixture-based tests, and documentation.
+
+Do not attempt to reverse-engineer every Oda endpoint in the first PR.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 22]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Typecheck
+        run: npm run typecheck --if-present
+
+      - name: Test
+        run: npm test --if-present
+
+      - name: Lint
+        run: npm run lint --if-present

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,89 +1,95 @@
-# AGENTS.md — Contributor & Agent Guidelines
+# AGENTS.md — Repository Instructions for Copilot Coding Agent
 
-This document describes conventions and rules for human contributors and AI coding agents working in this repository.
+You are working on oda-agent-kit, a TypeScript monorepo for interacting with the Norwegian online grocery store Oda.
 
-## Repository Layout
+## Primary goal
+
+Build and maintain a reusable Oda automation toolkit with:
+
+1. A reusable core library.
+2. A CLI for humans and debugging.
+3. An MCP server for model clients.
+4. An OpenClaw plugin and skill for agentic grocery workflows.
+
+## Architecture rule
+
+Keep Oda business logic in packages/core.
+
+Keep adapter packages thin:
+
+- packages/cli
+- packages/mcp-server
+- packages/openclaw-plugin
+
+Dependency direction must be:
 
 ```text
-oda-agent-kit/
-├── packages/
-│   ├── core/               # @oda-agent/core  — Oda API client & types
-│   ├── cli/                # @oda-agent/cli   — Terminal CLI
-│   ├── mcp-server/         # @oda-agent/mcp-server — MCP server
-│   └── openclaw-plugin/    # @oda-agent/openclaw-plugin
-├── docs/                   # Markdown documentation
-├── scripts/                # Build / CI helper scripts
-├── tsconfig.base.json      # Shared TS compiler options
-├── package.json            # Workspace root (npm workspaces)
-└── .env.example            # Env variable template (never commit .env)
+packages/core
+        ↑
+        ├── packages/cli
+        ├── packages/mcp-server
+        └── packages/openclaw-plugin
 ```
 
-## General Rules
+No adapter package may import another adapter package.
 
-1. **Never commit secrets.** `.env` files and credentials must never be checked in. Use `.env.example` for templates.
-2. **TypeScript only.** All source files must be `.ts` (no plain `.js` in `src/`).
-3. **Strict mode.** Every package extends `tsconfig.base.json` which enables `"strict": true`.
-4. **Conventional Commits.** Use the format `type(scope): message` (e.g. `feat(core): add product search`).
-5. **One concern per package.** Keep packages focused; cross-package dependencies should go through the public API, not internal paths.
+## Package names
 
-## Coding Standards
+Use these package names:
 
-- Use `async/await`; avoid raw Promise chains.
-- Prefer named exports over default exports.
-- Export all public types from `src/index.ts`.
-- Write unit tests for all non-trivial logic. Place tests in `src/__tests__/`.
-- Keep functions small and pure where possible.
-
-## Package-Specific Notes
-
-### `@oda-agent/core`
-
-- This is the only package allowed to make HTTP calls to the Oda API.
-- Export a typed `OdaClient` class as the primary entry point.
-- All API response types must live in `src/types.ts`.
-
-### `@oda-agent/cli`
-
-- Use `commander` for argument parsing.
-- The binary entry point is `src/cli.ts` (declared as `"bin"` in `package.json`).
-- Output should be human-readable by default; support `--json` flag for machine output.
-
-### `@oda-agent/mcp-server`
-
-- Implement using the `@modelcontextprotocol/sdk` package.
-- Each Oda capability (search, cart, orders, delivery) maps to one MCP tool.
-- Keep tool descriptions concise but accurate for LLM consumption.
-
-### `@oda-agent/openclaw-plugin`
-
-- Expose a plugin factory function as the default export of `src/index.ts`.
-- Depends on `@oda-agent/core` for all Oda API access.
-
-## Running the Workspace
-
-```bash
-# Install all dependencies
-npm install
-
-# Build all packages
-npm run build
-
-# Run all tests
-npm run test
-
-# Type-check without emitting
-npm run typecheck
-
-# Clean build artifacts
-npm run clean
+```text
+@oda-agent/core
+@oda-agent/cli
+@oda-agent/mcp-server
+@oda-agent/openclaw-plugin
 ```
 
-## Pull Request Checklist
+## Current stack
 
-- [ ] `npm run build` passes with no errors
-- [ ] `npm run test` passes
-- [ ] `npm run typecheck` passes
-- [ ] No new linting errors introduced
-- [ ] `.env` is **not** committed
-- [ ] New public APIs are exported from `src/index.ts`
-- [ ] Commit messages follow Conventional Commits
+Use:
+
+- TypeScript
+- npm workspaces
+- Jest (ts-jest) tests per package
+- commander for CLI
+- @modelcontextprotocol/sdk for MCP server
+
+Current compiler/module setup is CommonJS.
+
+Planned direction:
+
+- ESM modules
+- Zod at external API boundaries
+- fixture-first tests for schema and normalization layers
+
+When introducing planned changes, migrate consistently across packages.
+
+## Safety requirements
+
+- Never store plaintext credentials in the repository.
+- Use environment variables or local ignored session storage.
+- Keep .env.example; never commit .env.
+- Mutating tools must clearly describe intended changes.
+- Final order placement must not exist in v0.
+- Do not add payment logic.
+- Tests should use fixtures, not live Oda calls, by default.
+- MCP stdio server logs must go to stderr, not stdout.
+
+## Tool design guidance
+
+Expose medium-level tools, not raw HTTP endpoints.
+
+Read-only tools should be safe by default.
+
+Cart mutation tools should be optional and confirmation-protected.
+
+High-risk ordering tools are out of scope for v0.
+
+## Development workflow
+
+- Work in small PRs.
+- Prefer incremental changes over repo-wide restructuring.
+- Keep existing scripts and tests working: npm install, npm run build, npm test, npm run lint.
+- Use docs/copilot-prompts and docs/github-issues as optional planning aids.
+
+Do not jump directly to full ordering automation.

--- a/README.md
+++ b/README.md
@@ -1,106 +1,59 @@
 # Oda Agent Kit
 
-A TypeScript npm workspace monorepo for building reusable automation tools around Oda grocery shopping.
+A TypeScript npm-workspace monorepo for safe Oda grocery automation.
+
+The project is organized around reusable domain logic in `packages/core`, with thin adapters for CLI, MCP, and OpenClaw.
 
 ## Packages
 
-| Package | Description |
-|---------|-------------|
-| [`@oda-agent/core`](./packages/core) | Oda API client, types, and authentication helpers |
-| [`@oda-agent/cli`](./packages/cli) | CLI tool for interacting with Oda from the terminal |
-| [`@oda-agent/mcp-server`](./packages/mcp-server) | MCP server exposing Oda operations as AI tools |
-| [`@oda-agent/openclaw-plugin`](./packages/openclaw-plugin) | OpenClaw plugin for safe grocery planning and automation |
+- `@oda-agent/core`: shared Oda client interfaces, domain models, and core logic
+- `@oda-agent/cli`: terminal commands for local debugging and manual workflows
+- `@oda-agent/mcp-server`: MCP stdio server exposing tool-style operations
+- `@oda-agent/openclaw-plugin`: OpenClaw plugin integration layer
 
-## Features
+## Safety model
 
-- 🛒 **Grocery planning** — search products, manage shopping lists
-- 📦 **Order history** — analyse past orders and spending
-- 🛍️ **Cart preparation** — build and manage your cart programmatically
-- 🚚 **Delivery slot assistance** — find and book available delivery slots
-- 🤖 **AI integration** — MCP server and OpenClaw plugin for LLM-driven workflows
+- Read-only first.
+- Plan before mutation.
+- Explicit confirmation before cart mutation.
+- Stronger confirmation for delivery-slot changes.
+- No final order placement in v0.
 
-## Getting Started
+See `docs/safety-model.md` and `docs/tool-contracts.md` for details.
 
-### Prerequisites
+## Development
 
-- Node.js ≥ 18
-- npm ≥ 9
+Prerequisites:
 
-### Installation
+- Node.js >= 18
+- npm workspaces
+
+Install and validate:
 
 ```bash
 npm install
 npm run build
+npm test
+npm run lint
 ```
 
-### Configuration
-
-Copy `.env.example` to `.env` and fill in your Oda credentials:
-
-```bash
-cp .env.example .env
-```
-
-### Usage
-
-#### CLI
-
-```bash
-npx @oda-agent/cli --help
-```
-
-#### MCP Server
-
-```bash
-npx @oda-agent/mcp-server
-```
-
-## Development
-
-### Build all packages
-
-```bash
-npm run build
-```
-
-### Run tests
-
-```bash
-npm run test
-```
-
-### Type-check
-
-```bash
-npm run typecheck
-```
-
-### Clean build artifacts
-
-```bash
-npm run clean
-```
-
-## Repository Structure
+## Repo layout
 
 ```text
-oda-agent-kit/
-├── packages/
-│   ├── core/               # @oda-agent/core
-│   ├── cli/                # @oda-agent/cli
-│   ├── mcp-server/         # @oda-agent/mcp-server
-│   └── openclaw-plugin/    # @oda-agent/openclaw-plugin
-├── docs/                   # Documentation
-├── scripts/                # Development and CI scripts
-├── tsconfig.base.json      # Shared TypeScript config
-├── package.json            # Workspace root
-└── .env.example            # Environment variable template
+packages/
+  core/
+  cli/
+  mcp-server/
+  openclaw-plugin/
+docs/
+scripts/
 ```
 
-## Contributing
+## Planning artifacts
 
-See [AGENTS.md](./AGENTS.md) for contributor and agent guidelines.
+The repository includes optional Copilot planning artifacts in:
 
-## License
+- `docs/copilot-prompts/`
+- `docs/github-issues/`
 
-MIT
+They can be used to manage iterative implementation work, but they are not required for normal development.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,38 +1,102 @@
-# Architecture
+# Architecture — Oda Agent Kit
 
-## Overview
+## Summary
 
-`oda-agent-kit` is an npm workspace monorepo. The dependency graph is:
+This project uses one monorepo with multiple publishable npm packages.
 
+The reusable Oda logic lives in `packages/core`.
+
+Adapters live in separate packages:
+
+- `packages/cli`
+- `packages/mcp-server`
+- `packages/openclaw-plugin`
+
+## Dependency graph
+
+```text
+@oda-agent/core
+        ↑
+        ├── @oda-agent/cli
+        ├── @oda-agent/mcp-server
+        └── @oda-agent/openclaw-plugin
 ```
-@oda-agent/cli ──────────────┐
-@oda-agent/mcp-server ────────┤──▶ @oda-agent/core ──▶ Oda API
-@oda-agent/openclaw-plugin ──┘
-```
 
-`@oda-agent/core` is the only package that communicates with the Oda HTTP API. All other packages import and delegate to it.
-
-## Package Details
+## Package responsibilities
 
 ### `@oda-agent/core`
 
-Provides:
-- `OdaClient` — authenticated HTTP client for the Oda REST API
-- `OdaApiError` — typed error class
-- All data types (`OdaProduct`, `OdaCart`, `OdaOrder`, `OdaDeliverySlot`, …)
+Owns:
+
+- auth/session handling
+- HTTP client
+- CSRF handling
+- typed Oda domain models
+- product search
+- order history
+- cart read/write abstractions
+- shopping lists
+- delivery slots
+- household preference analysis
+
+Does not own:
+
+- CLI output formatting
+- MCP transport
+- OpenClaw plugin registration
 
 ### `@oda-agent/cli`
 
-A `commander`-based terminal tool. Reads credentials from environment variables (via `dotenv`). Supports `--json` flag for machine-readable output.
+Owns:
+
+- human-readable commands
+- JSON output mode
+- local debugging
+- smoke testing live APIs when explicitly enabled
 
 ### `@oda-agent/mcp-server`
 
-Wraps `OdaClient` into MCP tools using `@modelcontextprotocol/sdk`. Runs as a stdio MCP server so it can be embedded in any MCP-compatible AI host.
+Owns:
+
+- MCP tools
+- MCP resources
+- MCP prompts
+- JSON-RPC stdio server
 
 ### `@oda-agent/openclaw-plugin`
 
-Higher-level orchestration: grocery planning, order-history analysis, cart preparation, and delivery-slot selection. Built on top of `@oda-agent/core`.
+Owns:
 
-## Build System
+- OpenClaw plugin manifest
+- OpenClaw tool registration
+- OpenClaw skill instructions
+- tool grouping by risk level
 
-All packages are compiled with `tsc`. Each has its own `tsconfig.json` that extends `../../tsconfig.base.json`. The workspace root orchestrates builds via `npm run build --workspaces`.
+## Tool risk levels
+
+### Safe/read-only
+
+- auth status
+- search
+- product details
+- product images
+- cart read
+- order history
+- lists
+- slots
+
+### Medium/cart mutation
+
+- add items
+- update quantity
+- remove items
+- apply list to cart
+- reserve slot
+
+### High/final order
+
+- place order
+- change submitted order
+- add to existing order
+
+High-risk tools are intentionally out of scope for v0.

--- a/docs/copilot-prompts/00-bootstrap-monorepo.md
+++ b/docs/copilot-prompts/00-bootstrap-monorepo.md
@@ -1,0 +1,65 @@
+# Copilot task: Bootstrap the Oda Agent Kit monorepo
+
+Create the initial repository scaffold for `oda-agent-kit`.
+
+## Goal
+
+Create a TypeScript npm workspace monorepo with four packages:
+
+- `@oda-agent/core`
+- `@oda-agent/cli`
+- `@oda-agent/mcp-server`
+- `@oda-agent/openclaw-plugin`
+
+## Requirements
+
+Follow `AGENTS.md` and `.github/copilot-instructions.md`.
+
+Create:
+
+```text
+package.json
+package-lock.json
+tsconfig.base.json
+.gitignore
+.env.example
+README.md
+
+packages/core
+packages/cli
+packages/mcp-server
+packages/openclaw-plugin
+
+docs/
+scripts/
+```
+
+## Package setup
+
+Each package should have:
+
+- `package.json`
+- `tsconfig.json`
+- `src/index.ts` or equivalent
+- `npm run build`
+- placeholder tests where useful
+
+Root scripts:
+
+```json
+{
+  "build": "npm run build --workspaces",
+  "test": "npm run test --workspaces --if-present",
+  "lint": "npm run lint --workspaces --if-present",
+  "typecheck": "npm run typecheck --workspaces --if-present"
+}
+```
+
+## Acceptance criteria
+
+- `npm install` works.
+- `npm run build` works.
+- `npm test` works.
+- Package dependency direction is correct.
+- No live Oda API calls are implemented yet.
+- No secrets are committed.

--- a/docs/copilot-prompts/01-core-types-and-client.md
+++ b/docs/copilot-prompts/01-core-types-and-client.md
@@ -1,0 +1,31 @@
+# Copilot task: Add core types and Oda client skeleton
+
+## Goal
+
+Implement the first version of `packages/core`.
+
+## Scope
+
+Create:
+
+- `OdaClient`
+- `OdaClientOptions`
+- HTTP abstraction
+- session abstraction
+- typed domain models
+- Zod schemas for product/cart/order/list/slot placeholders
+- fixture-based tests
+
+## Out of scope
+
+- Live authentication.
+- Final order placement.
+- Payment.
+- Real user credentials.
+
+## Acceptance criteria
+
+- `@oda-agent/core` builds.
+- `OdaClient` can be constructed without network calls.
+- Fixture parsing tests exist.
+- Public exports are clean and documented.

--- a/docs/copilot-prompts/02-cli-basic-commands.md
+++ b/docs/copilot-prompts/02-cli-basic-commands.md
@@ -1,0 +1,31 @@
+# Copilot task: Add basic CLI commands
+
+## Goal
+
+Implement the first CLI wrapper around `@oda-agent/core`.
+
+## Commands
+
+Create placeholder commands:
+
+```bash
+oda auth status
+oda search <query>
+oda cart get
+oda orders list
+oda lists list
+oda slots list
+```
+
+## Requirements
+
+- Use core library interfaces.
+- Support `--json`.
+- Do not shell out to other packages.
+- Do not implement live Oda credentials yet unless core already supports it.
+
+## Acceptance criteria
+
+- `npx oda --help` works locally after build.
+- Commands have useful placeholder behavior or fixture-backed behavior.
+- CLI package builds and tests pass.

--- a/docs/copilot-prompts/03-mcp-readonly-server.md
+++ b/docs/copilot-prompts/03-mcp-readonly-server.md
@@ -1,0 +1,33 @@
+# Copilot task: Add MCP server read-only skeleton
+
+## Goal
+
+Create the MCP server package with read-only tools, resources, and prompts.
+
+## Tools
+
+Register these read-only tools:
+
+- `oda_auth_status`
+- `oda_search_products`
+- `oda_get_product`
+- `oda_get_product_image`
+- `oda_get_cart`
+- `oda_get_orders`
+- `oda_get_order_details`
+- `oda_get_shopping_lists`
+- `oda_get_delivery_slots`
+
+## Requirements
+
+- Use `@modelcontextprotocol/sdk`.
+- Use `@oda-agent/core`.
+- For stdio transport, normal logs must go to stderr, not stdout.
+- Do not implement cart mutation yet.
+
+## Acceptance criteria
+
+- MCP package builds.
+- Tool registration tests exist.
+- Server can start locally.
+- No stdout logging except MCP protocol messages.

--- a/docs/copilot-prompts/04-openclaw-plugin-skeleton.md
+++ b/docs/copilot-prompts/04-openclaw-plugin-skeleton.md
@@ -1,0 +1,33 @@
+# Copilot task: Add OpenClaw plugin skeleton
+
+## Goal
+
+Create `@oda-agent/openclaw-plugin` with OpenClaw manifest, read-only tools, and a skill.
+
+## Scope
+
+Create:
+
+```text
+packages/openclaw-plugin/openclaw.plugin.json
+packages/openclaw-plugin/src/index.ts
+packages/openclaw-plugin/src/tools/readOnlyTools.ts
+packages/openclaw-plugin/src/tools/cartMutationTools.ts
+packages/openclaw-plugin/src/tools/highRiskTools.ts
+packages/openclaw-plugin/skills/oda-shopping-assistant/SKILL.md
+```
+
+## Tool grouping
+
+Read-only tools should be default.
+
+Cart mutation tools should be optional/disabled until explicitly enabled.
+
+High-risk order placement tools should be documented but not implemented.
+
+## Acceptance criteria
+
+- Package builds.
+- Plugin manifest exists.
+- Skill explains the grocery workflow and safety model.
+- No order placement implementation.

--- a/docs/copilot-prompts/05-order-history-and-preferences.md
+++ b/docs/copilot-prompts/05-order-history-and-preferences.md
@@ -1,0 +1,38 @@
+# Copilot task: Add order history and household preference analysis
+
+## Goal
+
+Implement fixture-backed order history normalization and household staple analysis in `@oda-agent/core`.
+
+## Scope
+
+Add:
+
+- normalized `Order`
+- normalized `OrderItem`
+- `HouseholdPreference`
+- `StapleRule`
+- `analyzeOrderHistory`
+- `getHouseholdStaples`
+
+## Requirements
+
+The analysis should identify:
+
+- products bought frequently
+- average quantity
+- frequency category
+- confidence
+- reason string suitable for display to the user
+
+## Out of scope
+
+- Live endpoint reverse-engineering unless already available.
+- Cart mutation.
+- Final order placement.
+
+## Acceptance criteria
+
+- Fixture tests cover multiple orders.
+- Output is deterministic.
+- CLI or MCP can call the analysis function if already scaffolded.

--- a/docs/copilot-prompts/06-cart-plan-before-mutation.md
+++ b/docs/copilot-prompts/06-cart-plan-before-mutation.md
@@ -1,0 +1,36 @@
+# Copilot task: Add cart planning before mutation
+
+## Goal
+
+Implement a planning layer that proposes cart changes before executing them.
+
+## Scope
+
+Add:
+
+- `CartPlan`
+- `CartPlanItem`
+- `buildCartPlan`
+- `compareCartToUsual`
+- `findSubstitutes` placeholder
+
+## Requirements
+
+The plan should explain each item source:
+
+- order history
+- saved list
+- recipe
+- explicit user request
+- substitute
+- staple rule
+
+## Out of scope
+
+- Executing cart mutations.
+- Placing final orders.
+
+## Acceptance criteria
+
+- Tests prove plans are generated without changing cart state.
+- Plan output is suitable for agent confirmation messages.

--- a/docs/github-issues/001-bootstrap-monorepo.md
+++ b/docs/github-issues/001-bootstrap-monorepo.md
@@ -1,0 +1,30 @@
+# Bootstrap TypeScript npm workspace monorepo
+
+Labels: copilot, setup, monorepo
+
+## Goal
+
+Create the initial `oda-agent-kit` TypeScript npm workspace monorepo.
+
+## Scope
+
+Follow `docs/copilot-prompts/00-bootstrap-monorepo.md`.
+
+Create the root project, workspace packages, TypeScript configs, root scripts, `.gitignore`, `.env.example`, and placeholder package files.
+
+## Out of scope
+
+- Live Oda API calls
+- Real auth
+- Cart mutation
+- Order placement
+
+## Acceptance criteria
+
+- [ ] `npm install` works
+- [ ] `npm run build` works
+- [ ] `npm test` works
+- [ ] Four packages exist
+- [ ] Dependency direction is documented
+- [ ] No secrets committed
+

--- a/docs/github-issues/002-core-types-client.md
+++ b/docs/github-issues/002-core-types-client.md
@@ -1,0 +1,21 @@
+# Create core package types and Oda client skeleton
+
+Labels: copilot, core
+
+## Goal
+
+Create the first implementation of `@oda-agent/core`.
+
+## Scope
+
+Follow `docs/copilot-prompts/01-core-types-and-client.md`.
+
+## Acceptance criteria
+
+- [ ] `OdaClient` exists
+- [ ] Public domain types exist
+- [ ] Zod schemas exist
+- [ ] Fixture parsing tests exist
+- [ ] No network call happens in constructor
+- [ ] `npm run build --workspace=@oda-agent/core` works
+

--- a/docs/github-issues/003-cli-basic-commands.md
+++ b/docs/github-issues/003-cli-basic-commands.md
@@ -1,0 +1,23 @@
+# Add basic CLI commands
+
+Labels: copilot, cli
+
+## Goal
+
+Create a first CLI package using `@oda-agent/core`.
+
+## Scope
+
+Follow `docs/copilot-prompts/02-cli-basic-commands.md`.
+
+## Acceptance criteria
+
+- [ ] `oda --help` works after build
+- [ ] `oda auth status` exists
+- [ ] `oda search <query>` exists
+- [ ] `oda cart get` exists
+- [ ] `oda orders list` exists
+- [ ] `oda lists list` exists
+- [ ] `oda slots list` exists
+- [ ] `--json` option exists where useful
+

--- a/docs/github-issues/004-mcp-readonly-server.md
+++ b/docs/github-issues/004-mcp-readonly-server.md
@@ -1,0 +1,21 @@
+# Create MCP server with read-only tool skeleton
+
+Labels: copilot, mcp
+
+## Goal
+
+Create a first MCP server package with read-only Oda tools.
+
+## Scope
+
+Follow `docs/copilot-prompts/03-mcp-readonly-server.md`.
+
+## Acceptance criteria
+
+- [ ] MCP server package builds
+- [ ] Read-only tools are registered
+- [ ] Server starts locally
+- [ ] Tool registration tests exist
+- [ ] No cart mutation tools implemented yet
+- [ ] Logs use stderr, not stdout
+

--- a/docs/github-issues/005-openclaw-plugin-skeleton.md
+++ b/docs/github-issues/005-openclaw-plugin-skeleton.md
@@ -1,0 +1,21 @@
+# Create OpenClaw plugin skeleton and skill
+
+Labels: copilot, openclaw
+
+## Goal
+
+Create the OpenClaw plugin package and Oda shopping assistant skill.
+
+## Scope
+
+Follow `docs/copilot-prompts/04-openclaw-plugin-skeleton.md`.
+
+## Acceptance criteria
+
+- [ ] `openclaw.plugin.json` exists
+- [ ] Read-only tool module exists
+- [ ] Cart mutation tool module exists but is optional/disabled
+- [ ] High-risk tool module documents order placement as out of scope
+- [ ] `SKILL.md` exists
+- [ ] Package builds
+

--- a/docs/github-issues/006-order-history-preferences.md
+++ b/docs/github-issues/006-order-history-preferences.md
@@ -1,0 +1,20 @@
+# Implement order history normalization and staple analysis
+
+Labels: copilot, core, analysis
+
+## Goal
+
+Add fixture-backed order history normalization and household preference analysis.
+
+## Scope
+
+Follow `docs/copilot-prompts/05-order-history-and-preferences.md`.
+
+## Acceptance criteria
+
+- [ ] Normalized `Order` and `OrderItem` models exist
+- [ ] `analyzeOrderHistory` exists
+- [ ] `getHouseholdStaples` exists
+- [ ] Tests cover multiple orders
+- [ ] Output contains reason/confidence/frequency
+

--- a/docs/github-issues/007-cart-planning.md
+++ b/docs/github-issues/007-cart-planning.md
@@ -1,0 +1,20 @@
+# Implement cart planning before mutation
+
+Labels: copilot, core, cart
+
+## Goal
+
+Create a planning layer that proposes cart changes without changing the real cart.
+
+## Scope
+
+Follow `docs/copilot-prompts/06-cart-plan-before-mutation.md`.
+
+## Acceptance criteria
+
+- [ ] `CartPlan` model exists
+- [ ] `buildCartPlan` exists
+- [ ] `compareCartToUsual` exists
+- [ ] Tests prove no mutation happens
+- [ ] Output is suitable for confirmation messages
+

--- a/docs/github-issues/008-docs-safety-tool-contracts.md
+++ b/docs/github-issues/008-docs-safety-tool-contracts.md
@@ -1,0 +1,24 @@
+# Document safety model and tool contracts
+
+Labels: copilot, docs
+
+## Goal
+
+Improve documentation for safety levels, tool contracts, and package boundaries.
+
+## Scope
+
+Update:
+
+- `docs/architecture.md`
+- `docs/safety-model.md`
+- `docs/tool-contracts.md`
+- README
+
+## Acceptance criteria
+
+- [ ] Risk levels are clear
+- [ ] Read-only vs mutation vs high-risk tools are separated
+- [ ] Tool input/output examples exist
+- [ ] README explains package usage
+

--- a/docs/github-issues/009-ci-build-test.md
+++ b/docs/github-issues/009-ci-build-test.md
@@ -1,0 +1,21 @@
+# Add GitHub Actions CI for build and tests
+
+Labels: copilot, ci
+
+## Goal
+
+Add basic GitHub Actions workflow for install, build, typecheck, and tests.
+
+## Scope
+
+Create `.github/workflows/ci.yml`.
+
+## Acceptance criteria
+
+- [ ] CI runs on pull requests
+- [ ] CI runs on pushes to main
+- [ ] CI installs dependencies with `npm ci`
+- [ ] CI runs build
+- [ ] CI runs tests
+- [ ] CI runs lint/typecheck if scripts exist
+

--- a/docs/github-issues/010-publishing-plan.md
+++ b/docs/github-issues/010-publishing-plan.md
@@ -1,0 +1,29 @@
+# Add npm publishing plan for workspace packages
+
+Labels: copilot, release, docs
+
+## Goal
+
+Document how the packages should be published to npm.
+
+## Scope
+
+Create `docs/publishing.md`.
+
+Include:
+
+- package publishing order
+- npm workspace behavior
+- public/private package naming
+- versioning recommendation
+- why `core` is published separately
+- example install commands
+
+## Acceptance criteria
+
+- [ ] Publishing order is documented
+- [ ] Example package names are documented
+- [ ] CLI `bin` behavior is explained
+- [ ] MCP install example exists
+- [ ] OpenClaw plugin install example exists
+

--- a/docs/oda-api-notes.md
+++ b/docs/oda-api-notes.md
@@ -1,0 +1,23 @@
+# Oda API Notes
+
+This file is intentionally a placeholder.
+
+Use the existing public `mcp-oda` project as inspiration, but do not blindly copy code without review.
+
+Initial notes to investigate:
+
+- authentication flow
+- session/cookie persistence
+- CSRF handling for mutation requests
+- product search endpoint
+- product image fields
+- current cart endpoint
+- order history endpoint
+- saved lists endpoint
+- delivery slot endpoint
+
+Rules:
+
+- Add sanitized fixtures only.
+- Never commit real cookies, user IDs, addresses, payment info, or order details.
+- Prefer stable typed models over leaking raw Oda API response shapes throughout the project.

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,0 +1,58 @@
+# Publishing Plan
+
+## Packages
+
+The repo should publish these npm packages:
+
+```text
+@oda-agent/core
+@oda-agent/cli
+@oda-agent/mcp-server
+@oda-agent/openclaw-plugin
+```
+
+## Publishing order
+
+Publish `core` first:
+
+```bash
+npm publish --workspace=@oda-agent/core --access public
+npm publish --workspace=@oda-agent/cli --access public
+npm publish --workspace=@oda-agent/mcp-server --access public
+npm publish --workspace=@oda-agent/openclaw-plugin --access public
+```
+
+## Why separate packages?
+
+- CLI users should not install MCP/OpenClaw dependencies.
+- MCP users should not install CLI/OpenClaw dependencies.
+- OpenClaw users should not depend on the CLI.
+- `core` can be reused by future adapters.
+
+## Example installs
+
+CLI:
+
+```bash
+npm install -g @oda-agent/cli
+oda --help
+```
+
+MCP server:
+
+```json
+{
+  "mcpServers": {
+    "oda": {
+      "command": "npx",
+      "args": ["@oda-agent/mcp-server"]
+    }
+  }
+}
+```
+
+OpenClaw plugin:
+
+```bash
+openclaw plugins install @oda-agent/openclaw-plugin
+```

--- a/docs/safety-model.md
+++ b/docs/safety-model.md
@@ -1,0 +1,60 @@
+# Safety Model
+
+## Principles
+
+1. Read-only first.
+2. Plan before mutation.
+3. Mutate only after explicit confirmation.
+4. Never place final orders in v0.
+5. Do not store secrets in git.
+6. Do not log cookies, tokens, or user personal data.
+
+## Confirmation levels
+
+### Level 0 — Read-only
+
+Allowed without confirmation:
+
+- product search
+- order history read
+- cart read
+- list read
+- delivery slot read
+- product image read
+
+### Level 1 — Cart mutation
+
+Requires confirmation:
+
+- add item
+- remove item
+- change quantity
+- apply saved list to cart
+
+The confirmation message must show:
+
+- product name
+- quantity
+- price if available
+- whether it came from history/list/search
+- expected cart delta
+
+### Level 2 — Delivery mutation
+
+Requires stronger confirmation:
+
+- reserve delivery slot
+- change delivery slot
+
+The confirmation message must show:
+
+- date
+- time window
+- fee if available
+- expiry/reservation behavior if known
+
+### Level 3 — Final order
+
+Out of scope for v0.
+
+Do not implement `placeOrder` in v0.

--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -1,0 +1,100 @@
+# Tool Contracts
+
+## Read-only tools
+
+### `oda_search_products`
+
+Input:
+
+```json
+{
+  "query": "milk",
+  "limit": 10
+}
+```
+
+Output:
+
+```json
+{
+  "products": [
+    {
+      "id": "string",
+      "name": "string",
+      "brand": "string | null",
+      "price": {
+        "amount": 0,
+        "currency": "NOK"
+      },
+      "availability": "available | unavailable | unknown",
+      "images": [
+        {
+          "url": "string",
+          "kind": "thumbnail | large | unknown"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### `oda_get_orders`
+
+Input:
+
+```json
+{
+  "limit": 10
+}
+```
+
+Output:
+
+```json
+{
+  "orders": [
+    {
+      "id": "string",
+      "createdAt": "ISO datetime",
+      "deliveredAt": "ISO datetime | null",
+      "total": {
+        "amount": 0,
+        "currency": "NOK"
+      }
+    }
+  ]
+}
+```
+
+### `oda_get_household_staples`
+
+Input:
+
+```json
+{
+  "lookbackOrders": 20
+}
+```
+
+Output:
+
+```json
+{
+  "staples": [
+    {
+      "productId": "string",
+      "name": "string",
+      "averageQuantity": 1,
+      "frequency": "weekly | biweekly | monthly | occasional",
+      "confidence": 0.8,
+      "reason": "Bought in 8 of last 10 orders"
+    }
+  ]
+}
+```
+
+## Mutation tools
+
+Mutation tools must return proposed or executed deltas.
+
+They must be designed so that the agent can show a clear confirmation message before execution.

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,0 +1,40 @@
+const js = require('@eslint/js');
+const tsPlugin = require('@typescript-eslint/eslint-plugin');
+const tsParser = require('@typescript-eslint/parser');
+const globals = require('globals');
+
+module.exports = [
+  {
+    ignores: ['**/dist/**', '**/node_modules/**', '**/*.d.ts'],
+  },
+  js.configs.recommended,
+  {
+    files: ['**/*.ts'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: 2020,
+        sourceType: 'commonjs',
+      },
+      globals: {
+        ...globals.node,
+        ...globals.jest,
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tsPlugin,
+    },
+    rules: {
+      'no-undef': 'off',
+      'no-unused-vars': 'off',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          caughtErrorsIgnorePattern: '^_',
+        },
+      ],
+    },
+  },
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       ],
       "devDependencies": {
         "@types/node": "^20.17.0",
-        "typescript": "5.4.5"
+        "typescript": "~5.4.5"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -4965,7 +4965,7 @@
         "dotenv": "^16.4.0"
       },
       "bin": {
-        "oda": "dist/cli.js"
+        "oda": "dist/bin.js"
       },
       "devDependencies": {
         "@types/jest": "^29.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,12 @@
         "packages/*"
       ],
       "devDependencies": {
+        "@eslint/js": "^9.25.1",
         "@types/node": "^20.17.0",
+        "@typescript-eslint/eslint-plugin": "^8.30.1",
+        "@typescript-eslint/parser": "^8.30.1",
+        "eslint": "^9.25.1",
+        "globals": "^16.0.0",
         "typescript": "~5.4.5"
       },
       "engines": {
@@ -515,6 +520,204 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@hono/node-server": {
       "version": "1.19.14",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
@@ -525,6 +728,72 @@
       },
       "peerDependencies": {
         "hono": "^4"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -1024,6 +1293,13 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -1072,6 +1348,13 @@
         "pretty-format": "^29.0.0"
       }
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.19.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
@@ -1106,6 +1389,291 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.0.tgz",
+      "integrity": "sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/type-utils": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.59.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.0.tgz",
+      "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.0.tgz",
+      "integrity": "sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.59.0",
+        "@typescript-eslint/types": "^8.59.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.0.tgz",
+      "integrity": "sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.0.tgz",
+      "integrity": "sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.0.tgz",
+      "integrity": "sha512-3TRiZaQSltGqGeNrJzzr1+8YcEobKH9rHnqIp/1psfKFmhRQDNMGP5hBufanYTGznwShzVLs3Mz+gDN7HkWfXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0",
+        "@typescript-eslint/utils": "8.59.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.0.tgz",
+      "integrity": "sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.0.tgz",
+      "integrity": "sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.59.0",
+        "@typescript-eslint/tsconfig-utils": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/visitor-keys": "8.59.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.0.tgz",
+      "integrity": "sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.59.0",
+        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/typescript-estree": "8.59.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.59.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.0.tgz",
+      "integrity": "sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -1117,6 +1685,29 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/ajv": {
@@ -1805,6 +2396,13 @@
         }
       }
     },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -1978,6 +2576,236 @@
         "node": ">=8"
       }
     },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -1990,6 +2818,52 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/etag": {
@@ -2146,6 +3020,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -2195,6 +3076,19 @@
         "node": "^12.20 || >= 14.13"
       }
     },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -2242,6 +3136,27 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
@@ -2406,6 +3321,32 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -2543,6 +3484,43 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-fresh/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/import-local": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
@@ -2632,6 +3610,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -2650,6 +3638,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-number": {
@@ -3410,6 +4411,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -3429,6 +4437,13 @@
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -3440,6 +4455,16 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
       }
     },
     "node_modules/kleur": {
@@ -3460,6 +4485,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/lines-and-columns": {
@@ -3486,6 +4525,13 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -3816,6 +4862,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -3867,6 +4931,19 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
       "engines": {
         "node": ">=6"
       }
@@ -3997,6 +5074,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
@@ -4050,6 +5137,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/pure-rand": {
@@ -4555,6 +5652,54 @@
         "node": ">=8"
       }
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -4582,6 +5727,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/ts-jest": {
@@ -4661,6 +5819,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/type-detect": {
@@ -4775,6 +5946,16 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
@@ -4831,6 +6012,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/wordwrap": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "npm run build --workspaces --if-present",
+    "build": "bash ./scripts/build.sh",
     "test": "npm run test --workspaces --if-present",
     "lint": "npm run lint --workspaces --if-present",
     "clean": "npm run clean --workspaces --if-present",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,12 @@
     "typecheck": "npm run typecheck --workspaces --if-present"
   },
   "devDependencies": {
+    "@eslint/js": "^9.25.1",
+    "@typescript-eslint/eslint-plugin": "^8.30.1",
+    "@typescript-eslint/parser": "^8.30.1",
     "@types/node": "^20.17.0",
+    "eslint": "^9.25.1",
+    "globals": "^16.0.0",
     "typescript": "~5.4.5"
   },
   "engines": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "build": "tsc --project tsconfig.json",
     "clean": "rm -rf dist *.tsbuildinfo",
+    "lint": "eslint src --ext .ts",
     "typecheck": "tsc --project tsconfig.json --noEmit",
     "test": "jest"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "tsc --project tsconfig.json",
     "clean": "rm -rf dist *.tsbuildinfo",
+    "lint": "eslint src --ext .ts",
     "typecheck": "tsc --project tsconfig.json --noEmit",
     "test": "jest"
   },

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "tsc --project tsconfig.json",
     "clean": "rm -rf dist *.tsbuildinfo",
+    "lint": "eslint src --ext .ts",
     "typecheck": "tsc --project tsconfig.json --noEmit",
     "test": "jest",
     "start": "node dist/main.js"

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "tsc --project tsconfig.json",
     "clean": "rm -rf dist *.tsbuildinfo",
+    "lint": "eslint src --ext .ts",
     "typecheck": "tsc --project tsconfig.json --noEmit",
     "test": "jest"
   },

--- a/packages/openclaw-plugin/src/__tests__/plugin.test.ts
+++ b/packages/openclaw-plugin/src/__tests__/plugin.test.ts
@@ -1,5 +1,5 @@
 import { createOpenClawPlugin } from '../plugin';
-import type { OdaClient, OdaSearchResponse, OdaPage, OdaOrder, OdaDeliverySlot } from '@oda-agent/core';
+import type { OdaClient, OdaSearchResponse, OdaDeliverySlot } from '@oda-agent/core';
 
 function makeClient(overrides: Partial<OdaClient> = {}): OdaClient {
   return {

--- a/scripts/create-github-issues.sh
+++ b/scripts/create-github-issues.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage:
+#   ./scripts/create-github-issues.sh owner/repo
+#
+# Requirements:
+#   gh auth login
+#   gh repo view owner/repo
+
+REPO="${1:-}"
+
+if [[ -z "$REPO" ]]; then
+  echo "Usage: $0 owner/repo" >&2
+  exit 1
+fi
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "Error: GitHub CLI ('gh') is not installed or not in PATH." >&2
+  echo "Install instructions: https://cli.github.com/" >&2
+  echo "Then run: gh auth login" >&2
+  exit 1
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "Error: GitHub CLI is not authenticated." >&2
+  echo "Run: gh auth login" >&2
+  exit 1
+fi
+
+if ! gh repo view "$REPO" >/dev/null 2>&1; then
+  echo "Error: Repository '$REPO' is not accessible with current auth." >&2
+  exit 1
+fi
+
+LABELS_ENABLED=1
+
+ensure_label() {
+  local label="$1"
+
+  if gh label view "$label" --repo "$REPO" >/dev/null 2>&1; then
+    return
+  fi
+
+  echo "Creating missing label: $label"
+  if ! gh label create "$label" --repo "$REPO" --color "0E8A16" >/dev/null 2>&1; then
+    LABELS_ENABLED=0
+    echo "Warning: Could not create label '$label' (insufficient permissions)." >&2
+    echo "Warning: Continuing without labels for issue creation." >&2
+  fi
+}
+
+ensure_required_labels() {
+  local labels=(
+    copilot
+    setup
+    monorepo
+    core
+    cli
+    mcp
+    openclaw
+    analysis
+    cart
+    docs
+    ci
+    release
+  )
+
+  for label in "${labels[@]}"; do
+    if [[ "$LABELS_ENABLED" -eq 0 ]]; then
+      break
+    fi
+    ensure_label "$label"
+  done
+}
+
+filter_existing_labels() {
+  local csv="$1"
+  local filtered=()
+  local label
+
+  IFS=',' read -r -a raw_labels <<< "$csv"
+  for label in "${raw_labels[@]}"; do
+    if gh label view "$label" --repo "$REPO" >/dev/null 2>&1; then
+      filtered+=("$label")
+    fi
+  done
+
+  if [[ ${#filtered[@]} -eq 0 ]]; then
+    echo ""
+    return
+  fi
+
+  local joined
+  joined=$(IFS=,; echo "${filtered[*]}")
+  echo "$joined"
+}
+
+create_issue() {
+  local title="$1"
+  local labels="$2"
+  local body_file="$3"
+  local effective_labels="$labels"
+
+  echo "Creating issue: $title"
+
+  if [[ "$LABELS_ENABLED" -eq 0 ]]; then
+    effective_labels=""
+  else
+    effective_labels=$(filter_existing_labels "$labels")
+  fi
+
+  if [[ -n "$effective_labels" ]]; then
+    gh issue create \
+      --repo "$REPO" \
+      --title "$title" \
+      --label "$effective_labels" \
+      --body-file "$body_file"
+  else
+    gh issue create \
+      --repo "$REPO" \
+      --title "$title" \
+      --body-file "$body_file"
+  fi
+}
+
+  ensure_required_labels
+
+create_issue "Bootstrap TypeScript npm workspace monorepo" "copilot,setup,monorepo" "docs/github-issues/001-bootstrap-monorepo.md"
+create_issue "Create core package types and Oda client skeleton" "copilot,core" "docs/github-issues/002-core-types-client.md"
+create_issue "Add basic CLI commands" "copilot,cli" "docs/github-issues/003-cli-basic-commands.md"
+create_issue "Create MCP server with read-only tool skeleton" "copilot,mcp" "docs/github-issues/004-mcp-readonly-server.md"
+create_issue "Create OpenClaw plugin skeleton and skill" "copilot,openclaw" "docs/github-issues/005-openclaw-plugin-skeleton.md"
+create_issue "Implement order history normalization and staple analysis" "copilot,core,analysis" "docs/github-issues/006-order-history-preferences.md"
+create_issue "Implement cart planning before mutation" "copilot,core,cart" "docs/github-issues/007-cart-planning.md"
+create_issue "Document safety model and tool contracts" "copilot,docs" "docs/github-issues/008-docs-safety-tool-contracts.md"
+create_issue "Add GitHub Actions CI for build and tests" "copilot,ci" "docs/github-issues/009-ci-build-test.md"
+create_issue "Add npm publishing plan for workspace packages" "copilot,release,docs" "docs/github-issues/010-publishing-plan.md"
+
+echo "Done."


### PR DESCRIPTION
Closes #2

## Summary
- align README, AGENTS, and Copilot instructions with the current repo architecture and safety rules
- add CI workflow and a Copilot issue template
- add planning docs under docs/copilot-prompts and docs/github-issues
- add publishing, safety, architecture, and tool contract documentation
- add a resilient GitHub issue bootstrap script
- fix the root build to run workspaces in dependency order

## Validation
- npm install
- npm run build
- npm test
- npm run lint