### PR TITLE
Refine Oda OpenClaw plugin tool surface and naming

### DIFF
--- a/docs/tool-contracts.md
+++ b/docs/tool-contracts.md
@@ -196,7 +196,7 @@ Output:
 
 ## Mutation tools (Level 1 — cart)
 
-> **Note:** These tool names describe the planned v1 MCP server interface.  The current MCP server (`@oda-agent/mcp-server`) is **read-only** and does not yet expose mutation tools.  Equivalent functionality is available today via the OpenClaw plugin (`addToCart`, `removeFromCart`, `prepareCart`).
+> **Note:** These tool names describe the planned v1 MCP server interface. The current MCP server (`@oda-agent/mcp-server`) is **read-only** and does not yet expose mutation tools. Equivalent functionality is available today via the OpenClaw plugin through the higher-level `apply_cart_changes` tool.
 
 Mutation tools require explicit user confirmation before execution.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oda-agent-kit",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oda-agent-kit",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -6148,7 +6148,7 @@
     },
     "packages/cli": {
       "name": "@oda-agent/cli",
-      "version": "0.1.8",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@oda-agent/core": "*",
@@ -6166,7 +6166,7 @@
     },
     "packages/core": {
       "name": "@oda-agent/core",
-      "version": "0.1.8",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^3.3.2",
@@ -6180,7 +6180,7 @@
     },
     "packages/mcp-server": {
       "name": "@oda-agent/mcp-server",
-      "version": "0.1.8",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.10.0",
@@ -6196,7 +6196,7 @@
     },
     "packages/openclaw-plugin": {
       "name": "@oda-agent/openclaw-plugin",
-      "version": "0.1.8",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@oda-agent/core": "*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oda-agent-kit",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "private": true,
   "description": "TypeScript monorepo for building reusable automation tools around Oda grocery shopping",
   "workspaces": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oda-agent/cli",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "CLI tool for interacting with Oda grocery from the terminal",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oda-agent/core",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Oda API client, types, and authentication helpers",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oda-agent/mcp-server",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "MCP server exposing Oda operations as AI tools",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/openclaw-plugin/openclaw.plugin.json
+++ b/packages/openclaw-plugin/openclaw.plugin.json
@@ -1,8 +1,8 @@
 {
-  "id": "@oda-agent/openclaw-plugin",
-  "name": "oda-shopping-assistant",
+  "id": "oda-groceries",
+  "name": "Oda Groceries",
   "version": "0.1.8",
-  "description": "Oda grocery shopping assistant — safe cart planning, order history analysis, and delivery slot discovery.",
+  "description": "Browse groceries, review your shopping context, and apply confirmed cart changes.",
   "author": "oda-agent-kit",
   "license": "MIT",
   "configSchema": {
@@ -14,40 +14,20 @@
   "toolGroups": [
     {
       "name": "read-only",
-      "description": "Safe, read-only tools for browsing products, cart, orders, and delivery slots.",
+      "description": "Safe tools for browsing groceries and reviewing shopping context.",
       "enabled": true,
       "tools": [
         {
-          "name": "searchProducts",
-          "description": "Search for products in the Oda catalogue by keyword."
+          "name": "browse_oda_catalog",
+          "description": "Search the Oda catalog with a short, easy-to-scan result list."
         },
         {
-          "name": "getCart",
-          "description": "Retrieve the current shopping cart."
+          "name": "review_shopping_overview",
+          "description": "See the cart, saved lists, repeat buys, and delivery options together."
         },
         {
-          "name": "getOrders",
-          "description": "Fetch paginated order history."
-        },
-        {
-          "name": "getDeliverySlots",
-          "description": "List available delivery time slots."
-        },
-        {
-          "name": "getShoppingLists",
-          "description": "List the user's saved shopping lists."
-        },
-        {
-          "name": "analyseOrderHistory",
-          "description": "Analyse past orders and return a summary of frequently ordered products."
-        },
-        {
-          "name": "buildShoppingList",
-          "description": "Resolve plain-text queries into a structured shopping list without mutating the cart."
-        },
-        {
-          "name": "findCheapestDeliverySlot",
-          "description": "Return the cheapest available delivery slot without booking it."
+          "name": "plan_grocery_list",
+          "description": "Turn grocery requests into a matched plan without changing the cart."
         }
       ]
     },
@@ -57,20 +37,8 @@
       "enabled": false,
       "tools": [
         {
-          "name": "prepareCart",
-          "description": "Add all items from a shopping list to the cart. Requires explicit user confirmation before use."
-        },
-        {
-          "name": "addToCart",
-          "description": "Add a single product to the cart. Requires explicit user confirmation before use."
-        },
-        {
-          "name": "removeFromCart",
-          "description": "Remove an item from the cart by cart-item ID from getCart (`cart.items[].id`). Requires explicit user confirmation before use."
-        },
-        {
-          "name": "clearCart",
-          "description": "Remove all items from the cart. Requires explicit user confirmation before use."
+          "name": "apply_cart_changes",
+          "description": "Apply one confirmed cart change."
         }
       ]
     },

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oda-agent/openclaw-plugin",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "OpenClaw plugin for safe grocery planning and Oda automation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/openclaw-plugin/skills/oda-shopping-assistant/SKILL.md
+++ b/packages/openclaw-plugin/skills/oda-shopping-assistant/SKILL.md
@@ -27,14 +27,9 @@ These tools are safe to invoke without user confirmation. They observe but do no
 
 | Tool | Description |
 |------|-------------|
-| `searchProducts` | Search the Oda catalogue by keyword |
-| `getCart` | Read the current shopping cart |
-| `getOrders` | Fetch paginated order history |
-| `getDeliverySlots` | List available delivery time slots |
-| `getShoppingLists` | List the user's saved shopping lists |
-| `buildShoppingList` | Resolve plain-text queries into a structured shopping list |
-| `analyseOrderHistory` | Summarise past orders and frequently bought products |
-| `findCheapestDeliverySlot` | Find the cheapest available delivery slot (read-only) |
+| `browse_oda_catalog` | Search the Oda catalogue with a short result list |
+| `review_shopping_overview` | Review the cart, saved lists, repeat purchases, and delivery options in one call |
+| `plan_grocery_list` | Turn grocery requests into a matched shopping plan without mutating the cart |
 
 ### Cart-mutation tools (disabled by default)
 
@@ -42,10 +37,7 @@ These tools modify the shopping cart. They must be **explicitly enabled** by the
 
 | Tool | Description |
 |------|-------------|
-| `prepareCart` | Bulk-add all items from a shopping list to the cart |
-| `addToCart` | Add a single product to the cart |
-| `removeFromCart` | Remove a cart item by cart-item ID (`cart.items[].id`) |
-| `clearCart` | Remove all items from the cart |
+| `apply_cart_changes` | Apply one confirmed cart change, including adding products, removing products, clearing the cart, or applying a shopping plan |
 
 ### High-risk tools (not implemented in v0)
 
@@ -68,7 +60,7 @@ Order placement and payment are **out of scope** for v0. The `placeOrder` tool i
 ```
 User:  Can you suggest a weekly shop based on what I usually buy?
 
-Agent: Sure! Here's a proposed list based on your last 5 orders:
+Agent: I reviewed your account and built a proposed list based on your recent orders:
 
        1. Oat Milk 1L × 2   — ordered 4 times in the last 3 months
        2. Sourdough Bread × 1 — ordered every week
@@ -78,7 +70,7 @@ Agent: Sure! Here's a proposed list based on your last 5 orders:
 
 User:  Yes, add them.
 
-Agent: Adding 3 items to your cart…
+Agent: Applying the confirmed cart update…
        ✓ Oat Milk 1L × 2
        ✓ Sourdough Bread × 1
        ✓ Greek Yoghurt 500g × 2

--- a/packages/openclaw-plugin/src/__tests__/cartMutationTools.test.ts
+++ b/packages/openclaw-plugin/src/__tests__/cartMutationTools.test.ts
@@ -1,0 +1,58 @@
+import type { OdaClient } from '@oda-agent/core';
+import { updateCart } from '../tools/cartMutationTools';
+
+function makeClient(overrides: Partial<OdaClient> = {}): OdaClient {
+  return {
+    login: jest.fn(),
+    logout: jest.fn(),
+    searchProducts: jest.fn(),
+    getProduct: jest.fn(),
+    getCart: jest.fn(),
+    addToCart: jest.fn(),
+    removeFromCart: jest.fn(),
+    clearCart: jest.fn(),
+    getOrders: jest.fn(),
+    getOrder: jest.fn(),
+    getDeliverySlots: jest.fn(),
+    ...overrides,
+  } as unknown as OdaClient;
+}
+
+describe('updateCart', () => {
+  it('applies a shopping plan through a single tool call', async () => {
+    const addToCart = jest.fn().mockResolvedValue({});
+    const client = makeClient({ addToCart });
+
+    const result = await updateCart(client, {
+      mode: 'apply-plan',
+      plan: {
+        name: 'Weekly shop',
+        items: [
+          { productId: 1, quantity: 2 },
+          { productId: 2, quantity: 1 },
+        ],
+      },
+    });
+
+    expect(addToCart).toHaveBeenCalledTimes(2);
+    expect(result.mode).toBe('apply-plan');
+    expect(result.steps).toEqual([
+      'Add 2× product #1.',
+      'Add 1× product #2.',
+    ]);
+  });
+
+  it('removes multiple products through a single tool call', async () => {
+    const removeFromCart = jest.fn().mockResolvedValue(undefined);
+    const client = makeClient({ removeFromCart });
+
+    const result = await updateCart(client, {
+      mode: 'remove-products',
+      productIds: [11, 22],
+    });
+
+    expect(removeFromCart).toHaveBeenCalledWith(11);
+    expect(removeFromCart).toHaveBeenCalledWith(22);
+    expect(result.summary).toBe('Removed 2 product(s) from cart.');
+  });
+});

--- a/packages/openclaw-plugin/src/__tests__/entry.test.ts
+++ b/packages/openclaw-plugin/src/__tests__/entry.test.ts
@@ -3,8 +3,8 @@ import entry, { activate, register } from '../entry';
 import type { OpenClawApi, OpenClawToolDefinition } from '../entry';
 
 describe('OpenClaw plugin entry', () => {
-  it('exports a default plugin entry with id "@oda-agent/openclaw-plugin"', () => {
-    expect(entry.id).toBe('@oda-agent/openclaw-plugin');
+  it('exports a default plugin entry with id "oda-groceries"', () => {
+    expect(entry.id).toBe('oda-groceries');
   });
 
   it('has a non-empty name', () => {
@@ -47,23 +47,14 @@ describe('OpenClaw plugin entry', () => {
     entry.register(mockApi);
 
     const expectedTools = [
-      'searchProducts',
-      'getCart',
-      'getOrders',
-      'getDeliverySlots',
-      'getShoppingLists',
-      'analyseOrderHistory',
-      'buildShoppingList',
-      'findCheapestDeliverySlot',
-      'addToCart',
-      'removeFromCart',
-      'clearCart',
-      'prepareCart',
+      'browse_oda_catalog',
+      'review_shopping_overview',
+      'plan_grocery_list',
+      'apply_cart_changes',
     ];
 
-    for (const tool of expectedTools) {
-      expect(registeredTools).toContain(tool);
-    }
+    expect(registeredTools).toEqual(expect.arrayContaining(expectedTools));
+    expect(registeredTools).toHaveLength(expectedTools.length);
   });
 
   it('register succeeds without credentials and defers validation until tool use', async () => {
@@ -83,7 +74,7 @@ describe('OpenClaw plugin entry', () => {
 
     try {
       expect(() => entry.register(mockApi)).not.toThrow();
-      await expect(handlers.get('getCart')?.({})).rejects.toThrow(
+      await expect(handlers.get('review_shopping_overview')?.({})).rejects.toThrow(
         /Set both ODA_EMAIL and ODA_PASSWORD in the environment before launching OpenClaw/,
       );
     } finally {
@@ -93,12 +84,32 @@ describe('OpenClaw plugin entry', () => {
 
   it('uses environment credentials when a tool is invoked', async () => {
     const login = jest.spyOn(OdaClient.prototype, 'login').mockResolvedValue(undefined);
-    const getCart = jest.spyOn(OdaClient.prototype, 'getCart').mockResolvedValue({
-      id: 1,
-      items: [],
-      total_price: '0.00',
-      currency: 'NOK',
-      item_count: 0,
+    const searchProducts = jest.spyOn(OdaClient.prototype, 'searchProducts').mockResolvedValue({
+      query: 'milk',
+      count: 1,
+      results: [
+        {
+          id: 1,
+          full_name: 'Whole Milk 1L',
+          brand: 'Oda',
+          name: 'Milk',
+          front_url: '/products/1',
+          gross_price: '29.90',
+          gross_unit_price: '29.90',
+          unit_price_quantity_abbreviation: 'L',
+          unit_price_quantity_name: 'liter',
+          currency: 'NOK',
+          is_available: true,
+          is_sponsored: false,
+          promoted_product: false,
+          images: [],
+          discount: null,
+          availability: {
+            is_available: true,
+            description: null,
+          },
+        },
+      ],
     });
     const handlers = new Map<string, (params: unknown) => Promise<unknown>>();
 
@@ -117,19 +128,35 @@ describe('OpenClaw plugin entry', () => {
 
     try {
       entry.register(mockApi);
-      await expect(handlers.get('getCart')?.({})).resolves.toEqual({
-        id: 1,
-        items: [],
-        total_price: '0.00',
-        currency: 'NOK',
-        item_count: 0,
+      await expect(handlers.get('browse_oda_catalog')?.({ query: 'milk' })).resolves.toEqual({
+        query: 'milk',
+        totalMatches: 1,
+        products: [
+          {
+            productId: 1,
+            name: 'Whole Milk 1L',
+            brand: 'Oda',
+            price: '29.90',
+            currency: 'NOK',
+            available: true,
+          },
+        ],
       });
       expect(login).toHaveBeenCalledTimes(1);
-      expect(getCart).toHaveBeenCalledTimes(1);
+      expect(searchProducts).toHaveBeenCalledWith('milk');
+      const registeredToolLabels = new Map<string, string | undefined>();
+      entry.register({
+        registerTool: (tool: OpenClawToolDefinition) => {
+          registeredToolLabels.set(tool.name, tool.label);
+        },
+        getConfig: () => ({}),
+      });
+      expect(registeredToolLabels.get('browse_oda_catalog')).toBe('Browse Catalog');
+      expect(registeredToolLabels.get('review_shopping_overview')).toBe('Review Shopping Overview');
     } finally {
       replacedEnv.restore();
       login.mockRestore();
-      getCart.mockRestore();
+      searchProducts.mockRestore();
     }
   });
 });

--- a/packages/openclaw-plugin/src/__tests__/plugin.test.ts
+++ b/packages/openclaw-plugin/src/__tests__/plugin.test.ts
@@ -1,15 +1,7 @@
 import { createOpenClawPlugin } from '../plugin';
 import type { OdaClient, OdaSearchResponse, OdaDeliverySlot } from '@oda-agent/core';
 
-interface TestClientOverrides extends Partial<OdaClient> {
-  getShoppingLists?: jest.Mock;
-}
-
-interface TestClient extends OdaClient {
-  getShoppingLists?: jest.Mock;
-}
-
-function makeClient(overrides: TestClientOverrides = {}): TestClient {
+function makeClient(overrides: Partial<OdaClient> = {}): OdaClient {
   return {
     login: jest.fn(),
     logout: jest.fn(),
@@ -24,7 +16,7 @@ function makeClient(overrides: TestClientOverrides = {}): TestClient {
     getShoppingLists: jest.fn(),
     getDeliverySlots: jest.fn(),
     ...overrides,
-  } as unknown as TestClient;
+  } as unknown as OdaClient;
 }
 
 describe('createOpenClawPlugin', () => {

--- a/packages/openclaw-plugin/src/__tests__/plugin.test.ts
+++ b/packages/openclaw-plugin/src/__tests__/plugin.test.ts
@@ -1,7 +1,15 @@
 import { createOpenClawPlugin } from '../plugin';
 import type { OdaClient, OdaSearchResponse, OdaDeliverySlot } from '@oda-agent/core';
 
-function makeClient(overrides: Partial<OdaClient> = {}): OdaClient {
+interface TestClientOverrides extends Partial<OdaClient> {
+  getShoppingLists?: jest.Mock;
+}
+
+interface TestClient extends OdaClient {
+  getShoppingLists?: jest.Mock;
+}
+
+function makeClient(overrides: TestClientOverrides = {}): TestClient {
   return {
     login: jest.fn(),
     logout: jest.fn(),
@@ -13,12 +21,109 @@ function makeClient(overrides: Partial<OdaClient> = {}): OdaClient {
     clearCart: jest.fn(),
     getOrders: jest.fn(),
     getOrder: jest.fn(),
+    getShoppingLists: jest.fn(),
     getDeliverySlots: jest.fn(),
     ...overrides,
-  } as unknown as OdaClient;
+  } as unknown as TestClient;
 }
 
 describe('createOpenClawPlugin', () => {
+  describe('reviewAccount', () => {
+    it('returns a compact shopping overview in one call', async () => {
+      const client = makeClient({
+        getCart: jest.fn().mockResolvedValue({
+          id: 1,
+          items: [
+            {
+              id: 10,
+              quantity: 2,
+              line_price: '59.80',
+              product: {
+                id: 42,
+                full_name: 'Oat Milk 1L',
+                brand: 'Oatly',
+                name: 'Oat Milk',
+                front_url: '/products/42',
+                gross_price: '29.90',
+                gross_unit_price: '29.90',
+                unit_price_quantity_abbreviation: 'L',
+                unit_price_quantity_name: 'liter',
+                currency: 'NOK',
+                is_available: true,
+                is_sponsored: false,
+                promoted_product: false,
+                images: [],
+                discount: null,
+                availability: { is_available: true, description: null },
+              },
+            },
+          ],
+          total_price: '59.80',
+          currency: 'NOK',
+          item_count: 2,
+        }),
+        getShoppingLists: jest.fn().mockResolvedValue([
+          { id: 7, name: 'Weekly staples', items: [{}, {}] },
+        ]),
+        getOrders: jest.fn().mockResolvedValue({
+          count: 1,
+          next: null,
+          previous: null,
+          results: [
+            {
+              id: 100,
+              status: 'delivered',
+              delivery_date: '2024-01-01',
+              total_price: '59.80',
+              currency: 'NOK',
+              items: [
+                {
+                  quantity: 2,
+                  line_price: '59.80',
+                  product: {
+                    id: 42,
+                    full_name: 'Oat Milk 1L',
+                    brand: 'Oatly',
+                    name: 'Oat Milk',
+                    front_url: '/products/42',
+                    gross_price: '29.90',
+                    gross_unit_price: '29.90',
+                    unit_price_quantity_abbreviation: 'L',
+                    unit_price_quantity_name: 'liter',
+                    currency: 'NOK',
+                    is_available: true,
+                    is_sponsored: false,
+                    promoted_product: false,
+                    images: [],
+                    discount: null,
+                    availability: { is_available: true, description: null },
+                  },
+                },
+              ],
+            },
+          ],
+        }),
+        getDeliverySlots: jest.fn().mockResolvedValue([
+          { id: 1, start: '2024-01-01T10:00:00Z', end: '2024-01-01T12:00:00Z', price: '49.00', currency: 'NOK', is_available: true },
+          { id: 2, start: '2024-01-01T12:00:00Z', end: '2024-01-01T14:00:00Z', price: '29.00', currency: 'NOK', is_available: true },
+        ]),
+      });
+
+      const plugin = createOpenClawPlugin(client);
+      const review = await plugin.reviewAccount();
+
+      expect(review.cart?.itemCount).toBe(2);
+      expect(review.savedLists).toEqual([{ id: 7, name: 'Weekly staples', itemCount: 2 }]);
+      expect(review.orderHistory?.mostOrderedProducts[0]).toEqual({
+        productId: 42,
+        name: 'Oat Milk 1L',
+        brand: 'Oatly',
+        timesOrdered: 2,
+      });
+      expect(review.delivery?.cheapestSlot?.id).toBe(2);
+    });
+  });
+
   describe('buildShoppingList', () => {
     it('resolves queries to product IDs', async () => {
       const mockProduct = { id: 42, full_name: 'Oat Milk 1L' } as OdaSearchResponse['results'][0];
@@ -38,6 +143,40 @@ describe('createOpenClawPlugin', () => {
       const plugin = createOpenClawPlugin(client);
       const list = await plugin.buildShoppingList('Empty', [{ query: 'xyz', quantity: 1 }]);
       expect(list.items).toHaveLength(0);
+    });
+  });
+
+  describe('planGroceries', () => {
+    it('returns matched and unmatched requests with a shopping plan', async () => {
+      const mockProduct = { id: 42, full_name: 'Oat Milk 1L', brand: 'Oatly', gross_price: '29.90', currency: 'NOK' } as OdaSearchResponse['results'][0];
+      const client = makeClient({
+        searchProducts: jest
+          .fn()
+          .mockResolvedValueOnce({ results: [mockProduct], count: 1, query: 'oat milk' } as OdaSearchResponse)
+          .mockResolvedValueOnce({ results: [], count: 0, query: 'mystery item' } as OdaSearchResponse),
+      });
+      const plugin = createOpenClawPlugin(client);
+      const plan = await plugin.planGroceries('Weekly shop', [
+        { query: 'oat milk', quantity: 2 },
+        { query: 'mystery item' },
+      ]);
+
+      expect(plan.shoppingList).toEqual({
+        name: 'Weekly shop',
+        items: [{ productId: 42, quantity: 2 }],
+      });
+      expect(plan.matchedItems).toEqual([
+        {
+          query: 'oat milk',
+          quantity: 2,
+          productId: 42,
+          productName: 'Oat Milk 1L',
+          brand: 'Oatly',
+          price: '29.90',
+          currency: 'NOK',
+        },
+      ]);
+      expect(plan.unmatchedItems).toEqual([{ query: 'mystery item', quantity: 1 }]);
     });
   });
 

--- a/packages/openclaw-plugin/src/__tests__/readOnlyTools.test.ts
+++ b/packages/openclaw-plugin/src/__tests__/readOnlyTools.test.ts
@@ -8,15 +8,7 @@ import {
   getShoppingLists,
 } from '../tools/readOnlyTools';
 
-interface TestClientOverrides extends Partial<OdaClient> {
-  getShoppingLists?: jest.Mock;
-}
-
-interface TestClient extends OdaClient {
-  getShoppingLists?: jest.Mock;
-}
-
-function makeClient(overrides: TestClientOverrides = {}): TestClient {
+function makeClient(overrides: Partial<OdaClient> = {}): OdaClient {
   return {
     login: jest.fn(),
     logout: jest.fn(),
@@ -31,7 +23,7 @@ function makeClient(overrides: TestClientOverrides = {}): TestClient {
     getDeliverySlots: jest.fn(),
     getShoppingLists: jest.fn(),
     ...overrides,
-  } as unknown as TestClient;
+  } as unknown as OdaClient;
 }
 
 describe('readOnlyTools', () => {

--- a/packages/openclaw-plugin/src/__tests__/readOnlyTools.test.ts
+++ b/packages/openclaw-plugin/src/__tests__/readOnlyTools.test.ts
@@ -1,5 +1,6 @@
-import type { OdaClient, OdaSearchResponse, OdaCart, OdaPage, OdaOrder, OdaDeliverySlot, OdaShoppingList } from '@oda-agent/core';
+import type { OdaClient, OdaSearchResponse, OdaCart, OdaPage, OdaOrder, OdaDeliverySlot } from '@oda-agent/core';
 import {
+  browseCatalog,
   searchProducts,
   getCart,
   getOrders,
@@ -7,7 +8,15 @@ import {
   getShoppingLists,
 } from '../tools/readOnlyTools';
 
-function makeClient(overrides: Partial<OdaClient> = {}): OdaClient {
+interface TestClientOverrides extends Partial<OdaClient> {
+  getShoppingLists?: jest.Mock;
+}
+
+interface TestClient extends OdaClient {
+  getShoppingLists?: jest.Mock;
+}
+
+function makeClient(overrides: TestClientOverrides = {}): TestClient {
   return {
     login: jest.fn(),
     logout: jest.fn(),
@@ -22,10 +31,58 @@ function makeClient(overrides: Partial<OdaClient> = {}): OdaClient {
     getDeliverySlots: jest.fn(),
     getShoppingLists: jest.fn(),
     ...overrides,
-  } as unknown as OdaClient;
+  } as unknown as TestClient;
 }
 
 describe('readOnlyTools', () => {
+  describe('browseCatalog', () => {
+    it('returns a compact search result list', async () => {
+      const client = makeClient({
+        searchProducts: jest.fn().mockResolvedValue({
+          results: [
+            {
+              id: 42,
+              full_name: 'Oat Milk 1L',
+              brand: 'Oatly',
+              name: 'Oat Milk',
+              front_url: '/products/42',
+              gross_price: '29.90',
+              gross_unit_price: '29.90',
+              unit_price_quantity_abbreviation: 'L',
+              unit_price_quantity_name: 'liter',
+              currency: 'NOK',
+              is_available: true,
+              is_sponsored: false,
+              promoted_product: false,
+              images: [],
+              discount: null,
+              availability: { is_available: true, description: null },
+            },
+          ],
+          count: 1,
+          query: 'oat milk',
+        }),
+      });
+
+      const result = await browseCatalog(client, { query: 'oat milk' });
+
+      expect(result).toEqual({
+        query: 'oat milk',
+        totalMatches: 1,
+        products: [
+          {
+            productId: 42,
+            name: 'Oat Milk 1L',
+            brand: 'Oatly',
+            price: '29.90',
+            currency: 'NOK',
+            available: true,
+          },
+        ],
+      });
+    });
+  });
+
   describe('searchProducts', () => {
     it('delegates to client.searchProducts with the query', async () => {
       const mockResponse: OdaSearchResponse = { results: [], count: 0, query: 'milk' };
@@ -87,14 +144,15 @@ describe('readOnlyTools', () => {
 
   describe('getShoppingLists', () => {
     it('delegates to client.getShoppingLists', async () => {
-      const mockLists: OdaShoppingList[] = [
+      const mockLists = [
         { id: 10, name: 'Weekly', items: [] },
       ];
+      const getShoppingListsMock = jest.fn().mockResolvedValue(mockLists);
       const client = makeClient({
-        getShoppingLists: jest.fn().mockResolvedValue(mockLists),
+        getShoppingLists: getShoppingListsMock,
       });
       const result = await getShoppingLists(client);
-      expect(client.getShoppingLists).toHaveBeenCalledTimes(1);
+      expect(getShoppingListsMock).toHaveBeenCalledTimes(1);
       expect(result).toBe(mockLists);
     });
   });

--- a/packages/openclaw-plugin/src/entry.ts
+++ b/packages/openclaw-plugin/src/entry.ts
@@ -12,12 +12,12 @@
  */
 
 import { OdaClient } from '@oda-agent/core';
-import type { SearchProductsParams, GetOrdersParams } from './tools/readOnlyTools.js';
+import type { BrowseCatalogParams } from './tools/readOnlyTools.js';
 import * as readOnlyTools from './tools/readOnlyTools.js';
 import * as cartMutationTools from './tools/cartMutationTools.js';
 import { readEnvironmentCredentials } from './credentials.js';
 import { createOpenClawPlugin } from './plugin.js';
-import type { ShoppingList } from './plugin.js';
+import type { GroceryRequest, ReviewAccountOptions } from './plugin.js';
 
 // ---------------------------------------------------------------------------
 // OpenClaw plugin API surface (mirrors openclaw/plugin-sdk types)
@@ -37,6 +37,7 @@ export interface OpenClawApi {
 
 export interface OpenClawToolDefinition {
   name: string;
+  label?: string;
   description: string;
   parameters: {
     type: 'object';
@@ -79,12 +80,14 @@ interface PluginRuntime {
 function registerTool(
   api: OpenClawApi,
   name: string,
+  label: string,
   description: string,
   parameters: OpenClawToolDefinition['parameters'],
   handler: (params: unknown) => Promise<unknown>,
 ): void {
   api.registerTool({
     name,
+    label,
     description,
     parameters,
     async execute(_toolCallId: string, params: unknown) {
@@ -134,240 +137,161 @@ export function register(api: OpenClawApi): void {
     return authenticatedRuntimePromise;
   }
 
-  // ── Read-only tools ─────────────────────────────────────────────────────
+  // ── Workflow-oriented tools ─────────────────────────────────────────────
 
   registerTool(
     api,
-    'searchProducts',
-    'Search for products in the Oda catalogue by keyword.',
+    'browse_oda_catalog',
+    'Browse Catalog',
+    'Search the Oda catalog with a short, easy-to-scan result list.',
     {
       type: 'object',
       properties: {
         query: {
           type: 'string',
-          description: 'Search query for catalogue lookup.',
+          description: 'Search query for the Oda catalog.',
+        },
+        limit: {
+          type: 'number',
+          description: 'Maximum number of products to return. Defaults to 5.',
         },
       },
       required: ['query'],
     },
     async (params) => {
       const { client } = await ensureLoggedIn();
-      return readOnlyTools.searchProducts(client, params as SearchProductsParams);
+      return readOnlyTools.browseCatalog(client, params as BrowseCatalogParams);
     },
   );
 
   registerTool(
     api,
-    'getCart',
-    'Retrieve the current shopping cart.',
-    {
-      type: 'object',
-      properties: {},
-    },
-    async () => {
-      const { client } = await ensureLoggedIn();
-      return readOnlyTools.getCart(client);
-    },
-  );
-
-  registerTool(
-    api,
-    'getOrders',
-    'Fetch paginated order history.',
+    'review_shopping_overview',
+    'Review Shopping Overview',
+    'See the cart, saved lists, repeat buys, and delivery options together.',
     {
       type: 'object',
       properties: {
-        page: {
-          type: 'number',
-          description: 'Page number to fetch. Defaults to 1.',
+        includeCart: {
+          type: 'boolean',
+          description: 'Include a cart summary. Defaults to true.',
         },
-      },
-    },
-    async (params) => {
-      const { client } = await ensureLoggedIn();
-      return readOnlyTools.getOrders(client, params as GetOrdersParams | undefined);
-    },
-  );
-
-  registerTool(
-    api,
-    'getDeliverySlots',
-    'List available delivery time slots.',
-    {
-      type: 'object',
-      properties: {},
-    },
-    async () => {
-      const { client } = await ensureLoggedIn();
-      return readOnlyTools.getDeliverySlots(client);
-    },
-  );
-
-  registerTool(
-    api,
-    'getShoppingLists',
-    "List the user's saved shopping lists.",
-    {
-      type: 'object',
-      properties: {},
-    },
-    async () => {
-      const { client } = await ensureLoggedIn();
-      return readOnlyTools.getShoppingLists(client);
-    },
-  );
-
-  // ── Higher-level read-only helpers ──────────────────────────────────────
-
-  registerTool(
-    api,
-    'analyseOrderHistory',
-    'Analyse past orders and return a summary of frequently ordered products.',
-    {
-      type: 'object',
-      properties: {
-        maxPages: {
+        includeSavedLists: {
+          type: 'boolean',
+          description: 'Include saved shopping lists. Defaults to true.',
+        },
+        includeOrderHistory: {
+          type: 'boolean',
+          description: 'Include frequent purchase analysis. Defaults to true.',
+        },
+        includeDelivery: {
+          type: 'boolean',
+          description: 'Include delivery slot overview. Defaults to true.',
+        },
+        maxHistoryPages: {
           type: 'number',
           description: 'Maximum number of order-history pages to inspect.',
+        },
+        maxSavedLists: {
+          type: 'number',
+          description: 'Maximum number of saved lists to include.',
+        },
+        maxDeliverySlots: {
+          type: 'number',
+          description: 'Maximum number of delivery slots to include.',
         },
       },
     },
     async (params) => {
       const { plugin } = await ensureLoggedIn();
-      const p = params as { maxPages?: number } | undefined;
-      return plugin.analyseOrderHistory(p?.maxPages);
+      return plugin.reviewAccount((params ?? {}) as ReviewAccountOptions);
     },
   );
 
   registerTool(
     api,
-    'buildShoppingList',
-    'Resolve plain-text queries into a structured shopping list without mutating the cart.',
+    'plan_grocery_list',
+    'Plan Grocery List',
+    'Turn grocery requests into a matched plan without changing the cart.',
     {
       type: 'object',
       properties: {
         name: {
           type: 'string',
-          description: 'Shopping-list name.',
+          description: 'Plan name shown back to the user.',
         },
-        items: {
+        requests: {
           type: 'array',
-          description: 'Requested items to resolve into Oda products.',
+          description: 'Requested groceries to resolve into Oda products.',
           items: {
             type: 'object',
             properties: {
               query: {
                 type: 'string',
-                description: 'Free-text item query.',
+                description: 'Free-text grocery request.',
               },
               quantity: {
                 type: 'number',
-                description: 'Requested quantity.',
+                description: 'Requested quantity. Defaults to 1.',
               },
             },
-            required: ['query', 'quantity'],
+            required: ['query'],
           },
         },
       },
-      required: ['name', 'items'],
+      required: ['name', 'requests'],
     },
     async (params) => {
       const { plugin } = await ensureLoggedIn();
-      const p = params as { name: string; items: Array<{ query: string; quantity: number }> };
-      return plugin.buildShoppingList(p.name, p.items);
+      const plan = params as { name: string; requests: GroceryRequest[] };
+      return plugin.planGroceries(plan.name, plan.requests);
     },
   );
 
   registerTool(
     api,
-    'findCheapestDeliverySlot',
-    'Return the cheapest available delivery slot without booking it.',
-    {
-      type: 'object',
-      properties: {},
-    },
-    async () => {
-      const { plugin } = await ensureLoggedIn();
-      return plugin.findCheapestDeliverySlot();
-    },
-  );
-
-  // ── Cart-mutation tools (disabled by default in manifest) ───────────────
-
-  registerTool(
-    api,
-    'addToCart',
-    'Add a single product to the cart. Requires explicit user confirmation before use.',
+    'apply_cart_changes',
+    'Apply Cart Changes',
+    'Apply one confirmed cart change.',
     {
       type: 'object',
       properties: {
-        productId: {
-          type: 'number',
-          description: 'Oda product ID.',
-        },
-        quantity: {
-          type: 'number',
-          description: 'Quantity to add.',
-        },
-      },
-      required: ['productId', 'quantity'],
-    },
-    async (params) => {
-      const { client } = await ensureLoggedIn();
-      const p = params as { productId: number; quantity: number };
-      return cartMutationTools.addToCart(client, p.productId, p.quantity);
-    },
-  );
-
-  registerTool(
-    api,
-    'removeFromCart',
-    'Remove an item from the cart by product ID. Requires explicit user confirmation before use.',
-    {
-      type: 'object',
-      properties: {
-        productId: {
-          type: 'number',
-          description: 'Oda product ID to remove.',
-        },
-      },
-      required: ['productId'],
-    },
-    async (params) => {
-      const { client } = await ensureLoggedIn();
-      const p = params as { productId: number };
-      return cartMutationTools.removeFromCart(client, p.productId);
-    },
-  );
-
-  registerTool(
-    api,
-    'clearCart',
-    'Remove all items from the cart. Requires explicit user confirmation before use.',
-    {
-      type: 'object',
-      properties: {},
-    },
-    async () => {
-      const { client } = await ensureLoggedIn();
-      return cartMutationTools.clearCart(client);
-    },
-  );
-
-  registerTool(
-    api,
-    'prepareCart',
-    'Add all items from a shopping list to the cart. Requires explicit user confirmation before use.',
-    {
-      type: 'object',
-      properties: {
-        name: {
+        mode: {
           type: 'string',
-          description: 'Shopping-list name.',
+          description: 'Cart update mode.',
+          enum: ['apply-plan', 'add-products', 'remove-products', 'clear-cart'],
+        },
+        plan: {
+          type: 'object',
+          description: 'Shopping plan to apply when mode is "apply-plan".',
+          properties: {
+            name: {
+              type: 'string',
+              description: 'Shopping-plan name.',
+            },
+            items: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  productId: {
+                    type: 'number',
+                    description: 'Oda product ID.',
+                  },
+                  quantity: {
+                    type: 'number',
+                    description: 'Quantity to add.',
+                  },
+                },
+                required: ['productId', 'quantity'],
+              },
+            },
+          },
+          required: ['name', 'items'],
         },
         items: {
           type: 'array',
-          description: 'Resolved products to add to the cart.',
+          description: 'Products to add when mode is "add-products".',
           items: {
             type: 'object',
             properties: {
@@ -383,12 +307,19 @@ export function register(api: OpenClawApi): void {
             required: ['productId', 'quantity'],
           },
         },
+        productIds: {
+          type: 'array',
+          description: 'Products to remove when mode is "remove-products".',
+          items: {
+            type: 'number',
+          },
+        },
       },
-      required: ['name', 'items'],
+      required: ['mode'],
     },
     async (params) => {
       const { client } = await ensureLoggedIn();
-      return cartMutationTools.prepareCart(client, params as ShoppingList);
+      return cartMutationTools.updateCart(client, params as cartMutationTools.UpdateCartParams);
     },
   );
 }
@@ -403,10 +334,10 @@ export function activate(): void {
 // ---------------------------------------------------------------------------
 
 const pluginEntry = definePluginEntry({
-  id: '@oda-agent/openclaw-plugin',
-  name: 'oda-shopping-assistant',
+  id: 'oda-groceries',
+  name: 'Oda Groceries',
   description:
-    'Oda grocery shopping assistant — safe cart planning, order history analysis, and delivery slot discovery.',
+    'Browse groceries, review your shopping context, and apply confirmed cart changes.',
   register,
   activate,
 });

--- a/packages/openclaw-plugin/src/index.ts
+++ b/packages/openclaw-plugin/src/index.ts
@@ -1,4 +1,17 @@
 export { default, register, activate } from './entry.js';
 export type { OpenClawApi, OpenClawPluginEntry } from './entry.js';
 export { createOpenClawPlugin } from './plugin.js';
-export type { ShoppingList, OrderHistorySummary, OpenClawPlugin } from './plugin.js';
+export type {
+  AccountReview,
+  CartOverview,
+  DeliverySlotOverview,
+  GroceryPlan,
+  GroceryRequest,
+  OpenClawPlugin,
+  OrderHistorySummary,
+  PlannedGroceryItem,
+  ReviewAccountOptions,
+  SavedListOverview,
+  ShoppingList,
+  UnmatchedGroceryRequest,
+} from './plugin.js';

--- a/packages/openclaw-plugin/src/plugin.ts
+++ b/packages/openclaw-plugin/src/plugin.ts
@@ -1,4 +1,4 @@
-import type { OdaClient, OdaProduct, OdaDeliverySlot } from '@oda-agent/core';
+import type { OdaCart, OdaClient, OdaDeliverySlot, OdaProduct } from '@oda-agent/core';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -8,6 +8,107 @@ import type { OdaClient, OdaProduct, OdaDeliverySlot } from '@oda-agent/core';
 export interface ShoppingList {
   name: string;
   items: Array<{ productId: number; quantity: number }>;
+}
+
+/** A user-friendly summary of a cart item. */
+export interface CartOverviewItem {
+  productId: number;
+  name: string;
+  quantity: number;
+  linePrice: string;
+  available: boolean;
+}
+
+/** A compact cart summary for UI-facing tools. */
+export interface CartOverview {
+  itemCount: number;
+  totalPrice: string;
+  currency: string;
+  items: CartOverviewItem[];
+}
+
+/** A compact saved-list summary for UI-facing tools. */
+export interface SavedListOverview {
+  id: number;
+  name: string;
+  itemCount: number;
+}
+
+/** A compact product frequency summary. */
+export interface FrequentProductOverview {
+  productId: number;
+  name: string;
+  brand: string | null;
+  timesOrdered: number;
+}
+
+/** A compact delivery-slot summary. */
+export interface DeliverySlotOverview {
+  id: number;
+  start: string;
+  end: string;
+  price: string;
+  currency: string;
+}
+
+/** Options for the reviewAccount helper. */
+export interface ReviewAccountOptions {
+  includeCart?: boolean;
+  includeSavedLists?: boolean;
+  includeOrderHistory?: boolean;
+  includeDelivery?: boolean;
+  maxHistoryPages?: number;
+  maxSavedLists?: number;
+  maxDeliverySlots?: number;
+}
+
+/** User-facing account review returned by the OpenClaw tool. */
+export interface AccountReview {
+  cart?: CartOverview;
+  savedLists?: SavedListOverview[];
+  orderHistory?: {
+    totalOrders: number;
+    totalSpend: string;
+    currency: string;
+    mostOrderedProducts: FrequentProductOverview[];
+  };
+  delivery?: {
+    availableSlotCount: number;
+    cheapestSlot?: DeliverySlotOverview;
+    upcomingSlots: DeliverySlotOverview[];
+  };
+}
+
+/** A single request supplied to the grocery planner. */
+export interface GroceryRequest {
+  query: string;
+  quantity?: number;
+}
+
+/** A matched request in the grocery planner output. */
+export interface PlannedGroceryItem {
+  query: string;
+  quantity: number;
+  productId: number;
+  productName: string;
+  brand: string | null;
+  price: string;
+  currency: string;
+}
+
+/** A request that could not be matched to a product. */
+export interface UnmatchedGroceryRequest {
+  query: string;
+  quantity: number;
+}
+
+/** User-facing grocery plan returned by the OpenClaw tool. */
+export interface GroceryPlan {
+  name: string;
+  shoppingList: ShoppingList;
+  matchedItems: PlannedGroceryItem[];
+  unmatchedItems: UnmatchedGroceryRequest[];
+  summary: string;
 }
 
 /** Summary of a user's order history. */
@@ -20,6 +121,16 @@ export interface OrderHistorySummary {
 
 /** The OpenClaw plugin object returned by the factory. */
 export interface OpenClawPlugin {
+  /**
+   * Search the current account state in one call for day-to-day planning.
+   */
+  reviewAccount(options?: ReviewAccountOptions): Promise<AccountReview>;
+
+  /**
+   * Build a user-facing grocery plan from free-text requests.
+   */
+  planGroceries(name: string, requests: GroceryRequest[]): Promise<GroceryPlan>;
+
   /**
    * Search for products and build a shopping list from a plain-text description.
    * Returns a list of matched products ready to add to cart.
@@ -45,6 +156,118 @@ export interface OpenClawPlugin {
   >;
 }
 
+interface ResolvedShoppingRequests {
+  items: ShoppingList['items'];
+  matchedItems: PlannedGroceryItem[];
+  unmatchedItems: UnmatchedGroceryRequest[];
+}
+
+interface SavedListLike {
+  id: number;
+  name: string;
+  items: unknown[];
+}
+
+interface OdaClientWithShoppingLists extends OdaClient {
+  getShoppingLists?: () => Promise<SavedListLike[]>;
+}
+
+function summarizeCart(cart: OdaCart): CartOverview {
+  return {
+    itemCount: cart.item_count,
+    totalPrice: cart.total_price,
+    currency: cart.currency,
+    items: cart.items.map((item) => ({
+      productId: item.product.id,
+      name: item.product.full_name,
+      quantity: item.quantity,
+      linePrice: item.line_price,
+      available: item.product.is_available,
+    })),
+  };
+}
+
+function summarizeSavedLists(lists: SavedListLike[], maxSavedLists: number): SavedListOverview[] {
+  return lists.slice(0, maxSavedLists).map((list) => ({
+    id: list.id,
+    name: list.name,
+    itemCount: list.items.length,
+  }));
+}
+
+async function loadShoppingLists(client: OdaClient): Promise<SavedListLike[]> {
+  const clientWithLists = client as OdaClientWithShoppingLists;
+
+  if (typeof clientWithLists.getShoppingLists !== 'function') {
+    return [];
+  }
+
+  return clientWithLists.getShoppingLists();
+}
+
+function summarizeDeliverySlots(slots: OdaDeliverySlot[], maxDeliverySlots: number): AccountReview['delivery'] {
+  const available = slots
+    .filter((slot) => slot.is_available)
+    .sort((left, right) => parseFloat(left.price) - parseFloat(right.price));
+
+  return {
+    availableSlotCount: available.length,
+    cheapestSlot: available[0]
+      ? {
+          id: available[0].id,
+          start: available[0].start,
+          end: available[0].end,
+          price: available[0].price,
+          currency: available[0].currency,
+        }
+      : undefined,
+    upcomingSlots: available.slice(0, maxDeliverySlots).map((slot) => ({
+      id: slot.id,
+      start: slot.start,
+      end: slot.end,
+      price: slot.price,
+      currency: slot.currency,
+    })),
+  };
+}
+
+async function resolveShoppingRequests(
+  client: OdaClient,
+  requests: GroceryRequest[],
+): Promise<ResolvedShoppingRequests> {
+  const items: ShoppingList['items'] = [];
+  const matchedItems: PlannedGroceryItem[] = [];
+  const unmatchedItems: UnmatchedGroceryRequest[] = [];
+
+  for (const request of requests) {
+    const quantity = request.quantity ?? 1;
+    const results = await client.searchProducts(request.query);
+    const first = results.results[0];
+
+    if (!first) {
+      unmatchedItems.push({ query: request.query, quantity });
+      continue;
+    }
+
+    items.push({ productId: first.id, quantity });
+    matchedItems.push({
+      query: request.query,
+      quantity,
+      productId: first.id,
+      productName: first.full_name,
+      brand: first.brand,
+      price: first.gross_price,
+      currency: first.currency,
+    });
+  }
+
+  return {
+    items,
+    matchedItems,
+    unmatchedItems,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Factory
 // ---------------------------------------------------------------------------
@@ -65,62 +288,125 @@ export interface OpenClawPlugin {
  * ```
  */
 export function createOpenClawPlugin(client: OdaClient): OpenClawPlugin {
-  return {
-    async buildShoppingList(name, items) {
-      const resolved: ShoppingList['items'] = [];
+  async function analyseOrderHistory(maxPages = 5): Promise<OrderHistorySummary> {
+    const productCounts = new Map<number, { product: OdaProduct; count: number }>();
+    let totalOrders = 0;
+    let totalSpendCents = 0;
+    let currency = 'NOK';
 
-      for (const item of items) {
-        const results = await client.searchProducts(item.query);
-        const first = results.results[0];
-        if (first) {
-          resolved.push({ productId: first.id, quantity: item.quantity });
-        }
-      }
+    for (let page = 1; page <= maxPages; page++) {
+      const orderPage = await client.getOrders(page);
+      if (orderPage.results.length === 0) break;
 
-      return { name, items: resolved };
-    },
+      totalOrders += orderPage.results.length;
 
-    async analyseOrderHistory(maxPages = 5) {
-      const productCounts = new Map<number, { product: OdaProduct; count: number }>();
-      let totalOrders = 0;
-      let totalSpendCents = 0;
-      let currency = 'NOK';
+      for (const order of orderPage.results) {
+        currency = order.currency;
+        totalSpendCents += Math.round(parseFloat(order.total_price) * 100);
 
-      for (let page = 1; page <= maxPages; page++) {
-        const orderPage = await client.getOrders(page);
-        if (orderPage.results.length === 0) break;
-
-        totalOrders += orderPage.results.length;
-
-        for (const order of orderPage.results) {
-          currency = order.currency;
-          totalSpendCents += Math.round(parseFloat(order.total_price) * 100);
-
-          for (const item of order.items) {
-            const existing = productCounts.get(item.product.id);
-            if (existing) {
-              existing.count += item.quantity;
-            } else {
-              productCounts.set(item.product.id, { product: item.product, count: item.quantity });
-            }
+        for (const item of order.items) {
+          const existing = productCounts.get(item.product.id);
+          if (existing) {
+            existing.count += item.quantity;
+          } else {
+            productCounts.set(item.product.id, { product: item.product, count: item.quantity });
           }
         }
-
-        if (!orderPage.next) break;
       }
 
-      const sorted = [...productCounts.values()]
-        .sort((a, b) => b.count - a.count)
-        .slice(0, 10)
-        .map(({ product, count }) => ({ product, timesOrdered: count }));
+      if (!orderPage.next) break;
+    }
+
+    const sorted = [...productCounts.values()]
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 10)
+      .map(({ product, count }) => ({ product, timesOrdered: count }));
+
+    return {
+      totalOrders,
+      totalSpend: (totalSpendCents / 100).toFixed(2),
+      currency,
+      mostOrderedProducts: sorted,
+    };
+  }
+
+  async function buildShoppingList(name: string, items: Array<{ query: string; quantity: number }>): Promise<ShoppingList> {
+    const resolved = await resolveShoppingRequests(client, items);
+    return { name, items: resolved.items };
+  }
+
+  async function findCheapestDeliverySlot(): Promise<
+    { id: number; start: string; end: string; price: string; currency: string } | undefined
+  > {
+    const slots = await client.getDeliverySlots();
+    const available = slots.filter((slot: OdaDeliverySlot) => slot.is_available);
+    if (available.length === 0) return undefined;
+
+    return available.sort((left: OdaDeliverySlot, right: OdaDeliverySlot) => parseFloat(left.price) - parseFloat(right.price))[0];
+  }
+
+  return {
+    async reviewAccount(options = {}) {
+      const {
+        includeCart = true,
+        includeSavedLists = true,
+        includeOrderHistory = true,
+        includeDelivery = true,
+        maxHistoryPages = 5,
+        maxSavedLists = 5,
+        maxDeliverySlots = 3,
+      } = options;
+
+      const review: AccountReview = {};
+
+      if (includeCart) {
+        review.cart = summarizeCart(await client.getCart());
+      }
+
+      if (includeSavedLists) {
+        review.savedLists = summarizeSavedLists(await loadShoppingLists(client), maxSavedLists);
+      }
+
+      if (includeOrderHistory) {
+        const summary = await analyseOrderHistory(maxHistoryPages);
+        review.orderHistory = {
+          totalOrders: summary.totalOrders,
+          totalSpend: summary.totalSpend,
+          currency: summary.currency,
+          mostOrderedProducts: summary.mostOrderedProducts.map(({ product, timesOrdered }) => ({
+            productId: product.id,
+            name: product.full_name,
+            brand: product.brand,
+            timesOrdered,
+          })),
+        };
+      }
+
+      if (includeDelivery) {
+        review.delivery = summarizeDeliverySlots(await client.getDeliverySlots(), maxDeliverySlots);
+      }
+
+      return review;
+    },
+
+    async planGroceries(name, requests) {
+      const resolved = await resolveShoppingRequests(client, requests);
 
       return {
-        totalOrders,
-        totalSpend: (totalSpendCents / 100).toFixed(2),
-        currency,
-        mostOrderedProducts: sorted,
+        name,
+        shoppingList: {
+          name,
+          items: resolved.items,
+        },
+        matchedItems: resolved.matchedItems,
+        unmatchedItems: resolved.unmatchedItems,
+        summary: `Matched ${resolved.matchedItems.length} request(s) and left ${resolved.unmatchedItems.length} unmatched.`,
       };
     },
+
+    buildShoppingList,
+
+    analyseOrderHistory,
 
     async prepareCart(list) {
       for (const item of list.items) {
@@ -128,12 +414,6 @@ export function createOpenClawPlugin(client: OdaClient): OpenClawPlugin {
       }
     },
 
-    async findCheapestDeliverySlot() {
-      const slots = await client.getDeliverySlots();
-      const available = slots.filter((s: OdaDeliverySlot) => s.is_available);
-      if (available.length === 0) return undefined;
-
-      return available.sort((a: OdaDeliverySlot, b: OdaDeliverySlot) => parseFloat(a.price) - parseFloat(b.price))[0];
-    },
+    findCheapestDeliverySlot,
   };
 }

--- a/packages/openclaw-plugin/src/plugin.ts
+++ b/packages/openclaw-plugin/src/plugin.ts
@@ -168,9 +168,9 @@ interface SavedListLike {
   items: unknown[];
 }
 
-interface OdaClientWithShoppingLists extends OdaClient {
+type OdaClientWithShoppingLists = {
   getShoppingLists?: () => Promise<SavedListLike[]>;
-}
+};
 
 function summarizeCart(cart: OdaCart): CartOverview {
   return {

--- a/packages/openclaw-plugin/src/tools/cartMutationTools.ts
+++ b/packages/openclaw-plugin/src/tools/cartMutationTools.ts
@@ -29,6 +29,20 @@ export interface CartMutationResult {
   summary: string;
 }
 
+/** Parameters for the higher-level updateCart tool. */
+export interface UpdateCartParams {
+  mode: 'apply-plan' | 'add-products' | 'remove-products' | 'clear-cart';
+  plan?: ShoppingList;
+  items?: Array<{ productId: number; quantity: number }>;
+  productIds?: number[];
+}
+
+/** Result of the higher-level updateCart tool. */
+export interface CartUpdateResult extends CartMutationResult {
+  mode: UpdateCartParams['mode'];
+  steps: string[];
+}
+
 // ---------------------------------------------------------------------------
 // Tool implementations
 // ---------------------------------------------------------------------------
@@ -89,4 +103,74 @@ export async function prepareCart(
   return {
     summary: `Added ${list.items.length} item(s) from list "${list.name}" to cart.`,
   };
+}
+
+/**
+ * Apply one cart update intent by composing the lower-level mutation helpers.
+ */
+export async function updateCart(
+  client: OdaClient,
+  params: UpdateCartParams,
+): Promise<CartUpdateResult> {
+  switch (params.mode) {
+    case 'apply-plan': {
+      if (!params.plan) {
+        throw new Error('updateCart with mode "apply-plan" requires a shopping plan.');
+      }
+
+      const result = await prepareCart(client, params.plan);
+      return {
+        mode: params.mode,
+        summary: result.summary,
+        steps: params.plan.items.map(
+          (item) => `Add ${item.quantity}× product #${item.productId}.`,
+        ),
+      };
+    }
+
+    case 'add-products': {
+      if (!params.items || params.items.length === 0) {
+        throw new Error('updateCart with mode "add-products" requires at least one item.');
+      }
+
+      const steps: string[] = [];
+      for (const item of params.items) {
+        const result = await addToCart(client, item.productId, item.quantity);
+        steps.push(result.summary);
+      }
+
+      return {
+        mode: params.mode,
+        summary: `Added ${params.items.length} product(s) to cart.`,
+        steps,
+      };
+    }
+
+    case 'remove-products': {
+      if (!params.productIds || params.productIds.length === 0) {
+        throw new Error('updateCart with mode "remove-products" requires at least one product ID.');
+      }
+
+      const steps: string[] = [];
+      for (const productId of params.productIds) {
+        const result = await removeFromCart(client, productId);
+        steps.push(result.summary);
+      }
+
+      return {
+        mode: params.mode,
+        summary: `Removed ${params.productIds.length} product(s) from cart.`,
+        steps,
+      };
+    }
+
+    case 'clear-cart': {
+      const result = await clearCart(client);
+      return {
+        mode: params.mode,
+        summary: result.summary,
+        steps: [result.summary],
+      };
+    }
+  }
 }

--- a/packages/openclaw-plugin/src/tools/readOnlyTools.ts
+++ b/packages/openclaw-plugin/src/tools/readOnlyTools.ts
@@ -16,7 +16,7 @@
  * these primitives without performing any writes.
  */
 
-import type { OdaClient, OdaSearchResponse, OdaCart, OdaPage, OdaOrder, OdaDeliverySlot, OdaShoppingList } from '@oda-agent/core';
+import type { OdaClient, OdaSearchResponse, OdaCart, OdaPage, OdaOrder, OdaDeliverySlot } from '@oda-agent/core';
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -27,10 +27,40 @@ export interface SearchProductsParams {
   query: string;
 }
 
+/** Parameters for the browseCatalog tool. */
+export interface BrowseCatalogParams {
+  query: string;
+  limit?: number;
+}
+
+/** A compact search result for UI-facing catalog browsing. */
+export interface CatalogBrowseResult {
+  query: string;
+  totalMatches: number;
+  products: Array<{
+    productId: number;
+    name: string;
+    brand: string | null;
+    price: string;
+    currency: string;
+    available: boolean;
+  }>;
+}
+
 /** Parameters for the getOrders tool. */
 export interface GetOrdersParams {
   /** Page number, 1-based. Defaults to 1. */
   page?: number;
+}
+
+interface SavedListLike {
+  id: number;
+  name: string;
+  items: unknown[];
+}
+
+interface OdaClientWithShoppingLists extends OdaClient {
+  getShoppingLists?: () => Promise<SavedListLike[]>;
 }
 
 // ---------------------------------------------------------------------------
@@ -46,6 +76,30 @@ export async function searchProducts(
   params: SearchProductsParams,
 ): Promise<OdaSearchResponse> {
   return client.searchProducts(params.query);
+}
+
+/**
+ * Search the Oda catalogue and return a compact, UI-friendly result list.
+ */
+export async function browseCatalog(
+  client: OdaClient,
+  params: BrowseCatalogParams,
+): Promise<CatalogBrowseResult> {
+  const response = await client.searchProducts(params.query);
+  const limit = params.limit ?? 5;
+
+  return {
+    query: response.query,
+    totalMatches: response.count,
+    products: response.results.slice(0, limit).map((product) => ({
+      productId: product.id,
+      name: product.full_name,
+      brand: product.brand,
+      price: product.gross_price,
+      currency: product.currency,
+      available: product.is_available,
+    })),
+  };
 }
 
 /**
@@ -75,6 +129,12 @@ export async function getDeliverySlots(client: OdaClient): Promise<OdaDeliverySl
 /**
  * List the authenticated user's saved shopping lists.
  */
-export async function getShoppingLists(client: OdaClient): Promise<OdaShoppingList[]> {
-  return client.getShoppingLists();
+export async function getShoppingLists(client: OdaClient): Promise<SavedListLike[]> {
+  const clientWithLists = client as OdaClientWithShoppingLists;
+
+  if (typeof clientWithLists.getShoppingLists !== 'function') {
+    return [];
+  }
+
+  return clientWithLists.getShoppingLists();
 }

--- a/packages/openclaw-plugin/src/tools/readOnlyTools.ts
+++ b/packages/openclaw-plugin/src/tools/readOnlyTools.ts
@@ -59,9 +59,9 @@ interface SavedListLike {
   items: unknown[];
 }
 
-interface OdaClientWithShoppingLists extends OdaClient {
+type OdaClientWithShoppingLists = {
   getShoppingLists?: () => Promise<SavedListLike[]>;
-}
+};
 
 // ---------------------------------------------------------------------------
 // Tool implementations


### PR DESCRIPTION
## Summary

This PR refines the Oda OpenClaw plugin so the tool surface is smaller, more workflow-oriented, and easier to understand in the OpenClaw UI.

## What changed

- Replaced the larger low-level tool set with a smaller workflow-oriented surface:
  - `browse_oda_catalog`
  - `review_shopping_overview`
  - `plan_grocery_list`
  - `apply_cart_changes`
- Added explicit tool labels so OpenClaw can show clearer human-facing names in the tools catalog.
- Improved plugin identity and descriptions in the OpenClaw manifest.
- Added higher-level planning and review helpers with more compact UI-friendly response shapes.
- Updated skill/docs/tests to match the new tool surface and naming.

## Why

The previous plugin exposed too many raw API-shaped tools for day-to-day use. This change keeps the useful capability but presents it as a smaller set of higher-level actions with clearer intent for end users.

## Validation

- `npm test --workspace @oda-agent/openclaw-plugin`