### PR TITLE
Fix cart overview pricing and release 0.4.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -192,9 +192,9 @@ jobs:
 
       - name: Install and smoke-test @oda-agent/openclaw-plugin (unpinned core)
         # Install only the plugin without pinning core — this mirrors what a
-        # real consumer does. The plugin declares "@oda-agent/core": "*" so npm
-        # will resolve whichever core version is available on the registry.
-        # This validates that the '*' dependency range works end-to-end.
+        # real consumer does. The plugin declares a SemVer-compatible core range,
+        # so npm resolves the matching published core release transitively.
+        # This validates that the published dependency range works end-to-end.
         run: |
           VERSION="${{ needs.publish.outputs.version }}"
           SMOKE_DIR="$(mktemp -d)"

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ const products = await client.searchProducts("milk");
 
 Terminal commands for local debugging and manual workflows.
 
+Cart reads preserve the visible Oda pricing breakdown, including discounted
+line totals, subtotal lines, and non-item fees such as small-order and
+packaging charges.
+
 ```bash
 npm install -g @oda-agent/cli
 
@@ -46,6 +50,9 @@ Exposes read-only tools.  See [Tool Contracts](docs/tool-contracts.md) for the f
 ### `@oda-agent/openclaw-plugin`
 
 OpenClaw plugin and skill registration for agentic grocery workflows.
+
+The shopping overview keeps cart details available even when optional account
+endpoints like saved lists or order history fail for a specific account.
 
 ```ts
 import odaPlugin from "@oda-agent/openclaw-plugin";

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -43,12 +43,10 @@ when publishing:
 - Each package must be published individually. Both the workspace path form
   (`--workspace=packages/core`) and the package-name form
   (`--workspace=@oda-agent/core`) work; the examples below use the path form.
-- Workspace-local cross-dependencies currently use `"*"` (plain npm range, **not**
-  the `workspace:` protocol). The published tarball will therefore contain `"*"` as
-  the core dependency version, meaning any published version of `@oda-agent/core`
-  satisfies the requirement. To get deterministic pinning at publish time, migrate
-  to explicit version ranges (e.g. `"^0.2.0"`) or the `workspace:^` protocol before
-  each release.
+- Workspace-local cross-dependencies should use the current SemVer-compatible
+  release range for shared packages (for example `"^0.4.1"` for `@oda-agent/core`
+  when publishing `0.4.1`). This keeps published adapter packages aligned with the
+  core release they were validated against.
 - Always build (`npm run build`) **before** publishing so that `dist/` is up to date.
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "oda-agent-kit",
-  "version": "0.3.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "oda-agent-kit",
-      "version": "0.3.0",
+      "version": "0.4.1",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -6148,10 +6148,10 @@
     },
     "packages/cli": {
       "name": "@oda-agent/cli",
-      "version": "0.3.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
-        "@oda-agent/core": "*",
+        "@oda-agent/core": "^0.4.1",
         "commander": "^12.1.0",
         "dotenv": "^16.4.0"
       },
@@ -6166,7 +6166,7 @@
     },
     "packages/core": {
       "name": "@oda-agent/core",
-      "version": "0.3.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "node-fetch": "^3.3.2",
@@ -6180,11 +6180,11 @@
     },
     "packages/mcp-server": {
       "name": "@oda-agent/mcp-server",
-      "version": "0.3.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.10.0",
-        "@oda-agent/core": "*",
+        "@oda-agent/core": "^0.4.1",
         "dotenv": "^16.4.0",
         "zod": "^3.23.0"
       },
@@ -6196,10 +6196,10 @@
     },
     "packages/openclaw-plugin": {
       "name": "@oda-agent/openclaw-plugin",
-      "version": "0.3.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
-        "@oda-agent/core": "*"
+        "@oda-agent/core": "^0.4.1"
       },
       "devDependencies": {
         "@types/jest": "^29.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oda-agent-kit",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "description": "TypeScript monorepo for building reusable automation tools around Oda grocery shopping",
   "workspaces": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oda-agent/cli",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "CLI tool for interacting with Oda grocery from the terminal",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -18,7 +18,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@oda-agent/core": "*",
+    "@oda-agent/core": "^0.4.1",
     "commander": "^12.1.0",
     "dotenv": "^16.4.0"
   },

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -1,5 +1,5 @@
 import { formatCartOutput, program } from '../cli';
-import packageJson from '../../package.json';
+import { version } from '../version';
 
 function findCommand(path: string[]) {
   let current = program;
@@ -21,7 +21,7 @@ describe('CLI program', () => {
   });
 
   it('has the correct version', () => {
-    expect(program.version()).toBe(packageJson.version);
+    expect(program.version()).toBe(version);
   });
 
   it('registers expected subcommands', () => {

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -1,4 +1,5 @@
 import { formatCartOutput, program } from '../cli';
+import packageJson from '../../package.json';
 
 function findCommand(path: string[]) {
   let current = program;
@@ -20,7 +21,7 @@ describe('CLI program', () => {
   });
 
   it('has the correct version', () => {
-    expect(program.version()).toBe('0.1.0');
+    expect(program.version()).toBe(packageJson.version);
   });
 
   it('registers expected subcommands', () => {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -2,7 +2,7 @@ import 'dotenv/config';
 import { Command } from 'commander';
 import { OdaClient } from '@oda-agent/core';
 import type { OdaCart, OdaDeliverySlot } from '@oda-agent/core';
-import packageJson from '../package.json';
+import { version } from './version.js';
 
 type JsonOption = {
   json?: boolean;
@@ -66,7 +66,7 @@ const program = new Command();
 program
   .name('oda')
   .description('CLI for the Oda grocery API')
-  .version(packageJson.version);
+  .version(version);
 
 const auth = program.command('auth').description('Authentication helpers');
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -2,6 +2,7 @@ import 'dotenv/config';
 import { Command } from 'commander';
 import { OdaClient } from '@oda-agent/core';
 import type { OdaCart, OdaDeliverySlot } from '@oda-agent/core';
+import packageJson from '../package.json';
 
 type JsonOption = {
   json?: boolean;
@@ -65,7 +66,7 @@ const program = new Command();
 program
   .name('oda')
   .description('CLI for the Oda grocery API')
-  .version('0.1.0');
+  .version(packageJson.version);
 
 const auth = program.command('auth').description('Authentication helpers');
 

--- a/packages/cli/src/version.ts
+++ b/packages/cli/src/version.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+export const version: string = (require('../package.json') as { version: string }).version;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oda-agent/core",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Oda API client, types, and authentication helpers",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oda-agent/mcp-server",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "MCP server exposing Oda operations as AI tools",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.10.0",
-    "@oda-agent/core": "*",
+    "@oda-agent/core": "^0.4.1",
     "dotenv": "^16.4.0",
     "zod": "^3.23.0"
   },

--- a/packages/mcp-server/src/__tests__/server.test.ts
+++ b/packages/mcp-server/src/__tests__/server.test.ts
@@ -1,5 +1,6 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import packageJson from '../../package.json';
 import {
   createOdaMcpServer,
   EMPTY_INPUT_SCHEMA_JSON,
@@ -92,7 +93,7 @@ async function connectTestClient(client: Parameters<typeof createOdaMcpServer>[0
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   const mcpClient = new Client({
     name: 'test-client',
-    version: '0.1.0',
+    version: packageJson.version,
   });
 
   await Promise.all([server.connect(serverTransport), mcpClient.connect(clientTransport)]);

--- a/packages/mcp-server/src/__tests__/server.test.ts
+++ b/packages/mcp-server/src/__tests__/server.test.ts
@@ -1,6 +1,6 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import packageJson from '../../package.json';
+import { version } from '../version';
 import {
   createOdaMcpServer,
   EMPTY_INPUT_SCHEMA_JSON,
@@ -93,7 +93,7 @@ async function connectTestClient(client: Parameters<typeof createOdaMcpServer>[0
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   const mcpClient = new Client({
     name: 'test-client',
-    version: packageJson.version,
+    version,
   });
 
   await Promise.all([server.connect(serverTransport), mcpClient.connect(clientTransport)]);

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -1,6 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { OdaClient } from '@oda-agent/core';
+import packageJson from '../package.json';
 
 export const ZERO_ARGUMENT_TOOL_NAMES = [
   'oda_auth_status',
@@ -64,7 +65,7 @@ function createJsonResult(payload: unknown) {
 export function createOdaMcpServer(client: OdaReadOnlyClient, options: OdaMcpServerOptions = {}): McpServer {
   const server = new McpServer({
     name: 'oda-agent',
-    version: '0.1.0',
+    version: packageJson.version,
   });
 
   server.registerTool(

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -1,7 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { OdaClient } from '@oda-agent/core';
-import packageJson from '../package.json';
+import { version } from './version.js';
 
 export const ZERO_ARGUMENT_TOOL_NAMES = [
   'oda_auth_status',
@@ -65,7 +65,7 @@ function createJsonResult(payload: unknown) {
 export function createOdaMcpServer(client: OdaReadOnlyClient, options: OdaMcpServerOptions = {}): McpServer {
   const server = new McpServer({
     name: 'oda-agent',
-    version: packageJson.version,
+    version,
   });
 
   server.registerTool(

--- a/packages/mcp-server/src/version.ts
+++ b/packages/mcp-server/src/version.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+export const version: string = (require('../package.json') as { version: string }).version;

--- a/packages/openclaw-plugin/package.json
+++ b/packages/openclaw-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oda-agent/openclaw-plugin",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "OpenClaw plugin for safe grocery planning and Oda automation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -17,7 +17,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@oda-agent/core": "*"
+    "@oda-agent/core": "^0.4.1"
   },
   "devDependencies": {
     "@types/jest": "^29.5.0",

--- a/packages/openclaw-plugin/src/__tests__/plugin.test.ts
+++ b/packages/openclaw-plugin/src/__tests__/plugin.test.ts
@@ -235,6 +235,102 @@ describe('createOpenClawPlugin', () => {
         ],
       });
     });
+
+    it('tolerates sparse cart and saved-list payloads', async () => {
+      const client = makeClient({
+        getCart: jest.fn().mockResolvedValue({
+          id: 1,
+          label: '0 varer',
+          display_price: null,
+          subtotal_price: '0.00',
+          total_price: '0.00',
+          currency: 'NOK',
+          item_count: 0,
+        } as unknown),
+        getShoppingLists: jest.fn().mockResolvedValue([
+          { id: 7, name: 'Weekly staples' } as unknown,
+        ]),
+        getOrders: jest.fn().mockResolvedValue({
+          count: 0,
+          next: null,
+          previous: null,
+          results: [],
+        }),
+        getDeliverySlots: jest.fn().mockResolvedValue(undefined),
+      });
+
+      const plugin = createOpenClawPlugin(client);
+      const review = await plugin.reviewAccount();
+
+      expect(review.cart).toEqual({
+        itemCount: 0,
+        label: '0 varer',
+        displayPrice: null,
+        subtotalPrice: '0.00',
+        totalPrice: '0.00',
+        currency: 'NOK',
+        items: [],
+        summaryLines: [],
+        feeLines: [],
+      });
+      expect(review.savedLists).toEqual([{ id: 7, name: 'Weekly staples', itemCount: 0 }]);
+      expect(review.delivery).toEqual({
+        availableSlotCount: 0,
+        cheapestSlot: undefined,
+        upcomingSlots: [],
+      });
+    });
+
+    it('ignores shopping list 404s and still returns the rest of the overview', async () => {
+      const client = makeClient({
+        getCart: jest.fn().mockResolvedValue({
+          id: 1,
+          items: [],
+          total_price: '240.70',
+          currency: 'NOK',
+          item_count: 1,
+        }),
+        getShoppingLists: jest.fn().mockRejectedValue({ statusCode: 404, message: '/shopping-lists/: HTTP 404' }),
+        getOrders: jest.fn().mockResolvedValue({
+          count: 0,
+          next: null,
+          previous: null,
+          results: [],
+        }),
+        getDeliverySlots: jest.fn().mockResolvedValue([]),
+      });
+
+      const plugin = createOpenClawPlugin(client);
+      const review = await plugin.reviewAccount();
+
+      expect(review.cart?.totalPrice).toBe('240.70');
+      expect(review.savedLists).toEqual([]);
+      expect(review.orderHistory?.totalOrders).toBe(0);
+      expect(review.delivery?.availableSlotCount).toBe(0);
+    });
+
+    it('returns cart details even when optional overview sections fail', async () => {
+      const client = makeClient({
+        getCart: jest.fn().mockResolvedValue({
+          id: 1,
+          items: [],
+          total_price: '240.70',
+          currency: 'NOK',
+          item_count: 1,
+        }),
+        getShoppingLists: jest.fn().mockRejectedValue({ statusCode: 404, message: '/shopping-lists/: HTTP 404' }),
+        getOrders: jest.fn().mockRejectedValue(new Error('Invalid Oda API response for /orders/?page=1')),
+        getDeliverySlots: jest.fn().mockRejectedValue(new Error('Delivery slots unavailable')),
+      });
+
+      const plugin = createOpenClawPlugin(client);
+      const review = await plugin.reviewAccount();
+
+      expect(review.cart?.totalPrice).toBe('240.70');
+      expect(review.savedLists).toEqual([]);
+      expect(review.orderHistory).toBeUndefined();
+      expect(review.delivery).toBeUndefined();
+    });
   });
 
   describe('buildShoppingList', () => {

--- a/packages/openclaw-plugin/src/__tests__/readOnlyTools.test.ts
+++ b/packages/openclaw-plugin/src/__tests__/readOnlyTools.test.ts
@@ -89,7 +89,7 @@ describe('readOnlyTools', () => {
 
   describe('getCart', () => {
     it('delegates to client.getCart', async () => {
-      const mockCart: OdaCart = {
+      const mockCart = {
         id: 1,
         items: [],
         label: null,
@@ -100,7 +100,7 @@ describe('readOnlyTools', () => {
         total_price: '0.00',
         currency: 'NOK',
         item_count: 0,
-      };
+      } as OdaCart;
       const client = makeClient({
         getCart: jest.fn().mockResolvedValue(mockCart),
       });

--- a/packages/openclaw-plugin/src/plugin.ts
+++ b/packages/openclaw-plugin/src/plugin.ts
@@ -224,6 +224,16 @@ function hasStatusCode(error: unknown, statusCode: number): boolean {
     && (error as { statusCode?: number }).statusCode === statusCode;
 }
 
+function deriveUnitPrice(item: CartOverviewItemLike): string {
+  if (item.unit_price) {
+    return item.unit_price;
+  }
+  if (item.quantity > 0) {
+    return (parseFloat(item.line_price) / item.quantity).toFixed(2);
+  }
+  return item.line_price;
+}
+
 function summarizeCart(cart: OdaCart): CartOverview {
   const detailedCart = cart as OdaCartWithOverviewFields;
   const items = asArray(detailedCart.items);
@@ -243,7 +253,7 @@ function summarizeCart(cart: OdaCart): CartOverview {
       quantity: item.quantity,
       linePrice: item.line_price,
       originalLinePrice: item.original_line_price ?? null,
-      unitPrice: item.unit_price ?? item.line_price,
+      unitPrice: deriveUnitPrice(item),
       label: item.label ?? null,
       available: item.product.is_available,
     })),

--- a/packages/openclaw-plugin/src/plugin.ts
+++ b/packages/openclaw-plugin/src/plugin.ts
@@ -178,41 +178,82 @@ interface ResolvedShoppingRequests {
   unmatchedItems: UnmatchedGroceryRequest[];
 }
 
+interface CartOverviewItemLike {
+  product: OdaCart['items'][number]['product'];
+  quantity: number;
+  line_price: string;
+  original_line_price?: string | null;
+  unit_price?: string;
+  label?: string | null;
+}
+
+interface CartOverviewPriceLineLike {
+  label: string;
+  price: string;
+  kind: CartOverviewPriceLine['kind'];
+  details: string | null;
+}
+
+type OdaCartWithOverviewFields = OdaCart & {
+  label?: string | null;
+  display_price?: string | null;
+  subtotal_price?: string;
+  items?: CartOverviewItemLike[];
+  summary_lines?: CartOverviewPriceLineLike[];
+  fee_lines?: CartOverviewPriceLineLike[];
+};
+
 interface SavedListLike {
   id: number;
   name: string;
-  items: unknown[];
+  items?: unknown[];
 }
 
 type OdaClientWithShoppingLists = {
   getShoppingLists?: () => Promise<SavedListLike[]>;
 };
 
+function asArray<T>(value: T[] | null | undefined): T[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function hasStatusCode(error: unknown, statusCode: number): boolean {
+  return typeof error === 'object'
+    && error !== null
+    && 'statusCode' in error
+    && (error as { statusCode?: number }).statusCode === statusCode;
+}
+
 function summarizeCart(cart: OdaCart): CartOverview {
+  const detailedCart = cart as OdaCartWithOverviewFields;
+  const items = asArray(detailedCart.items);
+  const summaryLines = asArray(detailedCart.summary_lines);
+  const feeLines = asArray(detailedCart.fee_lines);
+
   return {
     itemCount: cart.item_count,
-    label: cart.label,
-    displayPrice: cart.display_price,
-    subtotalPrice: cart.subtotal_price,
+    label: detailedCart.label ?? null,
+    displayPrice: detailedCart.display_price ?? null,
+    subtotalPrice: detailedCart.subtotal_price ?? cart.total_price,
     totalPrice: cart.total_price,
     currency: cart.currency,
-    items: cart.items.map((item) => ({
+    items: items.map((item) => ({
       productId: item.product.id,
       name: item.product.full_name,
       quantity: item.quantity,
       linePrice: item.line_price,
-      originalLinePrice: item.original_line_price,
-      unitPrice: item.unit_price,
-      label: item.label,
+      originalLinePrice: item.original_line_price ?? null,
+      unitPrice: item.unit_price ?? item.line_price,
+      label: item.label ?? null,
       available: item.product.is_available,
     })),
-    summaryLines: cart.summary_lines.map((line) => ({
+    summaryLines: summaryLines.map((line) => ({
       label: line.label,
       price: line.price,
       kind: line.kind,
       details: line.details,
     })),
-    feeLines: cart.fee_lines.map((line) => ({
+    feeLines: feeLines.map((line) => ({
       label: line.label,
       price: line.price,
       kind: line.kind,
@@ -222,10 +263,10 @@ function summarizeCart(cart: OdaCart): CartOverview {
 }
 
 function summarizeSavedLists(lists: SavedListLike[], maxSavedLists: number): SavedListOverview[] {
-  return lists.slice(0, maxSavedLists).map((list) => ({
+  return asArray(lists).slice(0, maxSavedLists).map((list) => ({
     id: list.id,
     name: list.name,
-    itemCount: list.items.length,
+    itemCount: asArray(list.items).length,
   }));
 }
 
@@ -236,11 +277,19 @@ async function loadShoppingLists(client: OdaClient): Promise<SavedListLike[]> {
     return [];
   }
 
-  return clientWithLists.getShoppingLists();
+  try {
+    return asArray(await clientWithLists.getShoppingLists());
+  } catch (error) {
+    if (hasStatusCode(error, 404)) {
+      return [];
+    }
+
+    throw error;
+  }
 }
 
 function summarizeDeliverySlots(slots: OdaDeliverySlot[], maxDeliverySlots: number): AccountReview['delivery'] {
-  const available = slots
+  const available = asArray(slots)
     .filter((slot) => slot.is_available)
     .sort((left, right) => parseFloat(left.price) - parseFloat(right.price));
 
@@ -398,26 +447,38 @@ export function createOpenClawPlugin(client: OdaClient): OpenClawPlugin {
       }
 
       if (includeSavedLists) {
-        review.savedLists = summarizeSavedLists(await loadShoppingLists(client), maxSavedLists);
+        try {
+          review.savedLists = summarizeSavedLists(await loadShoppingLists(client), maxSavedLists);
+        } catch {
+          review.savedLists = [];
+        }
       }
 
       if (includeOrderHistory) {
-        const summary = await analyseOrderHistory(maxHistoryPages);
-        review.orderHistory = {
-          totalOrders: summary.totalOrders,
-          totalSpend: summary.totalSpend,
-          currency: summary.currency,
-          mostOrderedProducts: summary.mostOrderedProducts.map(({ product, timesOrdered }) => ({
-            productId: product.id,
-            name: product.full_name,
-            brand: product.brand,
-            timesOrdered,
-          })),
-        };
+        try {
+          const summary = await analyseOrderHistory(maxHistoryPages);
+          review.orderHistory = {
+            totalOrders: summary.totalOrders,
+            totalSpend: summary.totalSpend,
+            currency: summary.currency,
+            mostOrderedProducts: summary.mostOrderedProducts.map(({ product, timesOrdered }) => ({
+              productId: product.id,
+              name: product.full_name,
+              brand: product.brand,
+              timesOrdered,
+            })),
+          };
+        } catch {
+          review.orderHistory = undefined;
+        }
       }
 
       if (includeDelivery) {
-        review.delivery = summarizeDeliverySlots(await client.getDeliverySlots(), maxDeliverySlots);
+        try {
+          review.delivery = summarizeDeliverySlots(await client.getDeliverySlots(), maxDeliverySlots);
+        } catch {
+          review.delivery = undefined;
+        }
       }
 
       return review;


### PR DESCRIPTION
## Summary - harden the OpenClaw plugin shopping overview so optional Oda account endpoints fail soft instead of aborting the cart review - preserve the full cart pricing breakdown, including discounts and non-item fees, and add regression coverage for sparse cart payloads - bump all packages to 0.4.1, pin internal core dependency ranges, and source CLI/MCP versions from package metadata  ## Validation - npm test - npm run typecheck - npm run build - npm run lint - live-tested the CLI cart output with real Oda credentials - live-tested the installed OpenClaw plugin review_shopping_overview with real Oda credentials